### PR TITLE
Update bytes package to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ branch = "master"
 repository = "aembke/redis-protocol.rs"
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
 cookie-factory = "=0.2.4"
 crc16 = "0.3"
 log = "0.4"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -156,7 +156,7 @@ mod tests {
   }
 
   fn to_bytes(s: &str) -> BytesMut {
-    BytesMut::from(str_to_bytes(s))
+    BytesMut::from(&s[..])
   }
 
   fn empty_bytes() -> BytesMut {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -172,7 +172,7 @@ mod tests {
   }
 
   fn to_bytes(s: &str) -> BytesMut {
-    BytesMut::from(str_to_bytes(s))
+    BytesMut::from(&s[..])
   }
 
   fn empty_bytes() -> BytesMut {


### PR DESCRIPTION
Opening PR to update bytes library as we depend on the newer version of the bytes package. Not sure if this will be compatible with other Rust projects at Okta though.