### PR TITLE
4.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,17 @@ jobs:
       - run:
           name: Run tests with indexmap features
           command: cargo clean && eval `ssh-agent` && ssh-add ~/.ssh/id_rsa && cargo test --release --features index-map
+  tests-decode-mut:
+    docker:
+      - image: cimg/rust:1.57.0
+    steps:
+      - checkout
+      - run:
+          name: Clear the cargo git cache
+          command: rm -rf ~/.cargo/git/* && rm -rf ~/.cargo/registry/cache/*
+      - run:
+          name: Run tests with indexmap features
+          command: cargo clean && eval `ssh-agent` && ssh-add ~/.ssh/id_rsa && cargo test --release --features decode-mut
 
 workflows:
   version: 2
@@ -29,3 +40,4 @@ workflows:
     jobs:
       - tests-default
       - tests-indexmap
+      - tests-decode-mut

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,6 @@ jobs:
       - run:
           name: Run tests with indexmap features
           command: cargo clean && eval `ssh-agent` && ssh-add ~/.ssh/id_rsa && cargo test --release --features index-map
-  tests-cluster-hash-bytes:
-    docker:
-      - image: cimg/rust:1.57.0
-    steps:
-      - checkout
-      - run:
-          name: Clear the cargo git cache
-          command: rm -rf ~/.cargo/git/* && rm -rf ~/.cargo/registry/cache/*
-      - run:
-          name: Run tests with indexmap features
-          command: cargo clean && eval `ssh-agent` && ssh-add ~/.ssh/id_rsa && cargo test --release --features cluster-hash-bytes
 
 workflows:
   version: 2
@@ -40,4 +29,3 @@ workflows:
     jobs:
       - tests-default
       - tests-indexmap
-      - tests-cluster-hash-bytes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 authors = ["Alec Embke <aembke@gmail.com>"]
 description = "Structs and functions to implement the Redis protocol."
 homepage = "https://github.com/aembke/redis-protocol.rs"
-keywords = ["redis", "protocol", "nom", "encode", "decode"]
+keywords = ["redis", "protocol", "nom", "encode", "decode", "resp"]
 license = "MIT"
 name = "redis-protocol"
 readme = "README.md"
 repository = "https://github.com/aembke/redis-protocol.rs"
-version = "3.1.0"
+version = "4.0.0"
 edition = "2018"
 
 [badges.maintenance]
@@ -18,7 +18,8 @@ branch = "main"
 repository = "aembke/redis-protocol.rs"
 
 [dependencies]
-bytes = "1"
+bytes = "1.1"
+bytes-utils = "0.1"
 cookie-factory = "0.3"
 crc16 = "0.4"
 indexmap = { version = "1.6", optional = true }
@@ -34,7 +35,6 @@ itertools = "0.10"
 [features]
 default = []
 index-map = ["indexmap"]
-cluster-hash-bytes = []
 
 [lib]
 doc = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ pretty_env_logger = "0.4"
 default = []
 index-map = ["indexmap"]
 decode-logs = []
+decode-mut = []
 
 [lib]
 doc = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,12 @@ rand = "0.5"
 tokio-util = { version = "0.6", features = ["codec"] }
 tokio = { version = "1.12", features = ["full"] }
 itertools = "0.10"
+pretty_env_logger = "0.4"
 
 [features]
 default = []
 index-map = ["indexmap"]
+decode-logs = []
 
 [lib]
 doc = true

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ cargo add redis-protocol
 * Implements cluster key hashing.
 * Utility functions for converting from RESP2 to RESP3.
 
-This library relies heavily on the `BytesMut` interface to implement parsing logic such that buffer contents never need to move or be copied. 
+This library relies heavily on the `Bytes` interface to implement parsing logic such that buffer contents never need to move or be copied. 
 
 ## Examples
 
 ```rust
 use redis_protocol::resp2::prelude::*;
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 
 fn main() {
   let frame = Frame::BulkString("foobar".into());
@@ -43,7 +43,7 @@ fn main() {
   };
   println!("Encoded {} bytes into buffer with contents {:?}", len, buf);
   
-  let buf: BytesMut = "*3\r\n$3\r\nFoo\r\n$-1\r\n$3\r\nBar\r\n".into();
+  let buf: Bytes = "*3\r\n$3\r\nFoo\r\n$-1\r\n$3\r\nBar\r\n".into();
   let (frame, consumed) = match decode(&buf) {
     Ok(Some((f, c))) => (f, c),
     Ok(None) => panic!("Incomplete frame."),
@@ -59,6 +59,12 @@ fn main() {
 ## Decode Logs
 
 Use the `decode-logs` feature to enable special TRACE logs during the Frame decoding process.
+
+## Decoding `BytesMut`
+
+Using the default decoder interface with `BytesMut` can be challenging if the goal is to avoid copying or moving the buffer contents. 
+
+To better support this use case (such as the [codec](https://docs.rs/tokio-util/0.6.6/tokio_util/codec/index.html) interface) this library supports a `decode-mut` feature flag that can parse `BytesMut` without copying or moving the buffer contents.
 
 ## IndexMap
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ cargo add redis-protocol
 ## Features
 
 * Supports RESP2 and RESP3, including streaming frames.
-* Encode and decode with `BytesMut` or slices.
 * Parse publish-subscribe messages.
 * Support cluster redirection errors.
 * Implements cluster key hashing.
-* Utility functions for converting between RESP2 and RESP3.
+* Utility functions for converting from RESP2 to RESP3.
+
+This library relies heavily on the `BytesMut` interface to implement parsing logic such that buffer contents never need to move or be copied. 
 
 ## Examples
 
@@ -55,14 +56,10 @@ fn main() {
 }
 ```
 
+## Decode Logs
+
+Use the `decode-logs` feature to enable special TRACE logs during the Frame decoding process.
+
 ## IndexMap
 
 Enable the `index-map` feature to use [IndexMap](https://crates.io/crates/indexmap) instead of `HashMap` and `HashSet`. This is useful for testing and may also be useful to callers.
-
-## Tests
-
-To run the unit tests:
-
-```
-cargo test --features index-map
-```

--- a/src/decode_mut/frame.rs
+++ b/src/decode_mut/frame.rs
@@ -1,7 +1,6 @@
 use crate::decode_mut::utils::hash_tuple;
 use crate::resp3::types::{Auth, FrameKind, RespVersion, VerbatimStringFormat, NULL};
 use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind};
-use bytes::Bytes;
 use nom::IResult;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -415,29 +414,5 @@ impl DecodedIndexFrame {
         "Expected complete frame.",
       )),
     }
-  }
-
-  /// Convert the decoded frame into a streaming frame, returning an error if a complete variant is found.
-  pub fn into_streaming_frame(self) -> Result<StreamedIndexFrame, RedisProtocolError> {
-    match self {
-      DecodedIndexFrame::Streaming(frame) => Ok(frame),
-      DecodedIndexFrame::Complete(_) => Err(RedisProtocolError::new(
-        RedisProtocolErrorKind::DecodeError,
-        "Expected streamed frame.",
-      )),
-    }
-  }
-
-  /// Whether or not the decoded frame starts a stream.
-  pub fn is_streaming(&self) -> bool {
-    match *self {
-      DecodedIndexFrame::Streaming(_) => true,
-      _ => false,
-    }
-  }
-
-  /// Whether or not the decoded frame is a complete frame.
-  pub fn is_complete(&self) -> bool {
-    !self.is_streaming()
   }
 }

--- a/src/decode_mut/frame.rs
+++ b/src/decode_mut/frame.rs
@@ -1,0 +1,334 @@
+use crate::decode_mut::utils::hash_tuple;
+use crate::resp3::types::{Auth, FrameKind, RespVersion, VerbatimStringFormat, NULL};
+use bytes::Bytes;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Resp2IndexFrame {
+  SimpleString { start: usize, end: usize },
+  Error { start: usize, end: usize },
+  Integer(i64),
+  BulkString { start: usize, end: usize },
+  Array(Vec<Resp2IndexFrame>),
+  Null,
+}
+
+#[derive(Clone, Debug)]
+pub enum Resp3IndexFrame {
+  BlobString {
+    data: (usize, usize),
+    attributes: Option<(usize, usize)>,
+  },
+  BlobError {
+    data: (usize, usize),
+    attributes: Option<(usize, usize)>,
+  },
+  SimpleString {
+    data: (usize, usize),
+    attributes: Option<(usize, usize)>,
+  },
+  SimpleError {
+    data: (usize, usize),
+    attributes: Option<(usize, usize)>,
+  },
+  Boolean {
+    data: bool,
+    attributes: Option<(usize, usize)>,
+  },
+  Null,
+  Number {
+    data: i64,
+    attributes: Option<(usize, usize)>,
+  },
+  Double {
+    data: f64,
+    attributes: Option<(usize, usize)>,
+  },
+  BigNumber {
+    data: (usize, usize),
+    attributes: Option<(usize, usize)>,
+  },
+  VerbatimString {
+    data: (usize, usize),
+    attributes: Option<(usize, usize)>,
+    format: VerbatimStringFormat,
+  },
+  Array {
+    data: Vec<Resp3IndexFrame>,
+    attributes: Option<(usize, usize)>,
+  },
+  Map {
+    data: HashMap<Resp3IndexFrame, Resp3IndexFrame>,
+    attributes: Option<(usize, usize)>,
+  },
+  Set {
+    data: HashSet<Resp3IndexFrame>,
+    attributes: Option<(usize, usize)>,
+  },
+  Push {
+    data: Vec<Resp3IndexFrame>,
+    attributes: Option<(usize, usize)>,
+  },
+  Hello {
+    version: RespVersion,
+    auth: Option<Auth>,
+  },
+  ChunkedString((usize, usize)),
+}
+
+impl PartialEq for Resp3IndexFrame {
+  fn eq(&self, other: &Self) -> bool {
+    use self::Resp3IndexFrame::*;
+
+    match *self {
+      ChunkedString(ref b) => match *other {
+        ChunkedString(ref _b) => b == _b,
+        _ => false,
+      },
+      Array {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Array {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      BlobString {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          BlobString {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      SimpleString {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          SimpleString {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      SimpleError {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          SimpleError {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Number {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Number {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Null => match *other {
+        Null => true,
+        _ => false,
+      },
+      Boolean {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Boolean {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Double {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Double {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      BlobError {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          BlobError {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      VerbatimString {
+        ref data,
+        ref format,
+        ref attributes,
+      } => {
+        let (_data, _format, _attributes) = (data, format, attributes);
+        match *other {
+          VerbatimString {
+            ref data,
+            ref format,
+            ref attributes,
+          } => _data == data && _format == format && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Map {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Map {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Set {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Set {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Push {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          Push {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+      Hello { ref version, ref auth } => {
+        let (_version, _auth) = (version, auth);
+        match *other {
+          Hello { ref version, ref auth } => _version == version && _auth == auth,
+          _ => false,
+        }
+      }
+      BigNumber {
+        ref data,
+        ref attributes,
+      } => {
+        let (_data, _attributes) = (data, attributes);
+        match *other {
+          BigNumber {
+            ref data,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
+          _ => false,
+        }
+      }
+    }
+  }
+}
+
+impl Eq for Resp3IndexFrame {}
+
+impl Hash for Resp3IndexFrame {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    use self::Resp3IndexFrame::*;
+    self.kind().hash_prefix().hash(state);
+
+    match *self {
+      BlobString { ref data, .. } => hash_tuple(state, data),
+      SimpleString { ref data, .. } => hash_tuple(state, data),
+      SimpleError { ref data, .. } => hash_tuple(state, data),
+      Number { ref data, .. } => data.hash(state),
+      Null => NULL.hash(state),
+      Double { ref data, .. } => data.to_string().hash(state),
+      Boolean { ref data, .. } => data.hash(state),
+      BlobError { ref data, .. } => hash_tuple(state, data),
+      VerbatimString {
+        ref data, ref format, ..
+      } => {
+        format.hash(state);
+        hash_tuple(state, data);
+      }
+      ChunkedString(ref data) => hash_tuple(state, data),
+      BigNumber { ref data, .. } => hash_tuple(state, data),
+      _ => panic!("Invalid RESP3 data type to use as hash key."),
+    };
+  }
+}
+
+impl Resp3IndexFrame {
+  /// Read the associated `FrameKind`.
+  pub fn kind(&self) -> FrameKind {
+    use self::Resp3IndexFrame::*;
+
+    match *self {
+      Array { .. } => FrameKind::Array,
+      BlobString { .. } => FrameKind::BlobString,
+      SimpleString { .. } => FrameKind::SimpleString,
+      SimpleError { .. } => FrameKind::SimpleError,
+      Number { .. } => FrameKind::Number,
+      Null => FrameKind::Null,
+      Double { .. } => FrameKind::Double,
+      BlobError { .. } => FrameKind::BlobError,
+      VerbatimString { .. } => FrameKind::VerbatimString,
+      Boolean { .. } => FrameKind::Boolean,
+      Map { .. } => FrameKind::Map,
+      Set { .. } => FrameKind::Set,
+      Push { .. } => FrameKind::Push,
+      Hello { .. } => FrameKind::Hello,
+      BigNumber { .. } => FrameKind::BigNumber,
+      ChunkedString(ref inner) => {
+        if inner.1 - inner.0 == 0 {
+          FrameKind::EndStream
+        } else {
+          FrameKind::ChunkedString
+        }
+      }
+    }
+  }
+}

--- a/src/decode_mut/mod.rs
+++ b/src/decode_mut/mod.rs
@@ -1,4 +1,4 @@
-// it took an unfortunate amount of code to make this work
+// it took an unfortunate amount of code to make this work without copying buffer contents
 pub mod frame;
 pub mod resp2;
 pub mod resp3;

--- a/src/decode_mut/mod.rs
+++ b/src/decode_mut/mod.rs
@@ -1,0 +1,4 @@
+pub mod frame;
+pub mod resp2;
+pub mod resp3;
+pub mod utils;

--- a/src/decode_mut/mod.rs
+++ b/src/decode_mut/mod.rs
@@ -1,3 +1,4 @@
+// it took an unfortunate amount of code to make this work
 pub mod frame;
 pub mod resp2;
 pub mod resp3;

--- a/src/decode_mut/resp2.rs
+++ b/src/decode_mut/resp2.rs
@@ -213,6 +213,7 @@ fn freeze_parse(
 ///
 /// Unlike `decode` this function works on a mutable `BytesMut` buffer in order to parse frames without copying the inner buffer contents
 /// and will automatically split off the consumed bytes before returning. If an error or `None` is returned the buffer will not be modified.
+#[cfg_attr(docsrs, doc(cfg(feature = "decode-mut")))]
 pub fn decode_mut(buf: &mut BytesMut) -> Result<Option<(Resp2Frame, usize, Bytes)>, RedisProtocolError> {
   let (offset, len) = (0, buf.len());
 

--- a/src/decode_mut/resp2.rs
+++ b/src/decode_mut/resp2.rs
@@ -1,0 +1,410 @@
+use crate::decode_mut::frame::Resp2IndexFrame;
+use crate::decode_mut::utils::range_to_bytes;
+use crate::nom_bytes::NomBytes;
+use crate::resp2::decode::{isize_to_usize, NULL_LEN};
+use crate::resp2::types::{
+  Frame as Resp2Frame, FrameKind, ARRAY_BYTE, BULKSTRING_BYTE, ERROR_BYTE, INTEGER_BYTE, SIMPLESTRING_BYTE,
+};
+use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind, CRLF};
+use bytes::{Bytes, BytesMut};
+use bytes_utils::Str;
+use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
+use nom::multi::{count as nom_count, many0_count as nom_many0_count};
+use nom::number::streaming::be_u8;
+use nom::sequence::terminated as nom_terminated;
+use nom::{AsBytes, Err as NomErr, IResult};
+use std::str;
+
+pub fn to_isize(s: &[u8]) -> Result<isize, RedisParseError<&[u8]>> {
+  str::from_utf8(s)?
+    .parse::<isize>()
+    .map_err(|_| RedisParseError::new_custom("to_isize", "Failed to parse as integer."))
+}
+
+pub fn to_i64(s: &[u8]) -> Result<i64, RedisParseError<&[u8]>> {
+  str::from_utf8(s)?
+    .parse::<i64>()
+    .map_err(|_| RedisParseError::new_custom("to_i64", "Failed to parse as integer."))
+}
+
+// TODO optimize this using the nom counting interfaces
+fn d_read_to_crlf(input: (&[u8], usize)) -> IResult<(&[u8], usize), usize, RedisParseError<&[u8]>> {
+  decode_log!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", input.0);
+  let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
+  Ok(((input_bytes, input.1 + data.len() + 2), data.len()))
+}
+
+fn d_read_to_crlf_take(input: (&[u8], usize)) -> IResult<(&[u8], usize), &[u8], RedisParseError<&[u8]>> {
+  decode_log!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", input.0);
+  let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
+  Ok(((input_bytes, input.1 + data.len() + 2), data))
+}
+
+fn d_read_prefix_len(input: (&[u8], usize)) -> IResult<(&[u8], usize), isize, RedisParseError<&[u8]>> {
+  let (input, data) = d_read_to_crlf_take(input)?;
+  decode_log!("Reading prefix len. Data: {:?}", str::from_utf8(data));
+  Ok((input, etry!(to_isize(&data))))
+}
+
+fn d_frame_type(input: (&[u8], usize)) -> IResult<(&[u8], usize), FrameKind, RedisParseError<&[u8]>> {
+  let (input_bytes, byte) = be_u8(input.0)?;
+  decode_log!(
+    input_bytes,
+    "Reading frame type. Kind byte: {:?}, remaining: {:?}",
+    byte,
+    input_bytes
+  );
+  let kind = match byte {
+    SIMPLESTRING_BYTE => FrameKind::SimpleString,
+    ERROR_BYTE => FrameKind::Error,
+    INTEGER_BYTE => FrameKind::Integer,
+    BULKSTRING_BYTE => FrameKind::BulkString,
+    ARRAY_BYTE => FrameKind::Array,
+    _ => e!(RedisParseError::new_custom("frame_type", "Invalid frame type.")),
+  };
+
+  Ok(((input_bytes, input.1 + 1), kind))
+}
+
+fn d_parse_simplestring(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let offset = input.1;
+  let ((input, next_offset), len) = d_read_to_crlf(input)?;
+  Ok((
+    (input, next_offset),
+    Resp2IndexFrame::SimpleString {
+      start: offset,
+      end: offset + len,
+    },
+  ))
+}
+
+fn d_parse_integer(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
+  let parsed = etry!(to_i64(&data));
+  Ok(((input, next_offset), Resp2IndexFrame::Integer(parsed)))
+}
+
+// assumes the '$-1\r\n' has been consumed already, since nulls look like bulk strings until the length prefix is parsed,
+// and parsing the length prefix consumes the trailing \r\n in the underlying `terminated!` call
+fn d_parse_null(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  Ok((input, Resp2IndexFrame::Null))
+}
+
+fn d_parse_error(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let offset = input.1;
+  let ((input, next_offset), len) = d_read_to_crlf(input)?;
+  Ok((
+    (input, next_offset),
+    Resp2IndexFrame::Error {
+      start: offset,
+      end: offset + len,
+    },
+  ))
+}
+
+fn d_parse_bulkstring(
+  input: (&[u8], usize),
+  len: usize,
+) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let offset = input.1;
+  let (input, data) = nom_terminated(nom_take(len), nom_take(2_usize))(input.0)?;
+  Ok((
+    (input, offset + len + 2),
+    Resp2IndexFrame::BulkString {
+      start: offset,
+      end: offset + data.len(),
+    },
+  ))
+}
+
+fn d_parse_bulkstring_or_null(
+  input: (&[u8], usize),
+) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let ((input, offset), len) = d_read_prefix_len(input)?;
+  decode_log!(input, "Parsing bulkstring, Length: {:?}, remaining: {:?}", len, input);
+
+  if len == NULL_LEN {
+    d_parse_null((input, offset))
+  } else {
+    d_parse_bulkstring((input, offset), etry!(isize_to_usize(len)))
+  }
+}
+
+fn d_parse_array_frames(
+  input: (&[u8], usize),
+  len: usize,
+) -> IResult<(&[u8], usize), Vec<Resp2IndexFrame>, RedisParseError<&[u8]>> {
+  decode_log!(
+    input.0,
+    _input,
+    "Parsing array frames. Length: {:?}, remaining: {:?}",
+    len,
+    input.0
+  );
+  nom_count(d_parse_frame, len)(input)
+}
+
+fn d_parse_array(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let ((input, offset), len) = d_read_prefix_len(input)?;
+  decode_log!(input, "Parsing array. Length: {:?}, remaining: {:?}", len, input);
+
+  if len == NULL_LEN {
+    d_parse_null((input, offset))
+  } else {
+    let len = etry!(isize_to_usize(len));
+    let ((input, offset), frames) = d_parse_array_frames((input, offset), len)?;
+    Ok(((input, offset), Resp2IndexFrame::Array(frames)))
+  }
+}
+
+fn d_parse_frame(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFrame, RedisParseError<&[u8]>> {
+  let ((input, offset), kind) = d_frame_type(input)?;
+  decode_log!(input, "Parsed kind: {:?}, remaining: {:?}", kind, input);
+
+  match kind {
+    FrameKind::SimpleString => d_parse_simplestring((input, offset)),
+    FrameKind::Error => d_parse_error((input, offset)),
+    FrameKind::Integer => d_parse_integer((input, offset)),
+    FrameKind::BulkString => d_parse_bulkstring_or_null((input, offset)),
+    FrameKind::Array => d_parse_array((input, offset)),
+    _ => e!(RedisParseError::new_custom("parse_frame", "Invalid frame kind.")),
+  }
+}
+
+fn make_bytes_frame(buf: &Bytes, frame: Resp2IndexFrame) -> Result<Resp2Frame, RedisProtocolError> {
+  let out = match frame {
+    Resp2IndexFrame::Error { start, end } => {
+      let bytes = range_to_bytes(buf, start, end)?;
+      Resp2Frame::Error(Str::from_inner(bytes)?)
+    }
+    Resp2IndexFrame::SimpleString { start, end } => {
+      let bytes = range_to_bytes(buf, start, end)?;
+      Resp2Frame::SimpleString(bytes)
+    }
+    Resp2IndexFrame::BulkString { start, end } => {
+      let bytes = range_to_bytes(buf, start, end)?;
+      Resp2Frame::BulkString(bytes)
+    }
+    Resp2IndexFrame::Integer(i) => Resp2Frame::Integer(i),
+    Resp2IndexFrame::Null => Resp2Frame::Null,
+    Resp2IndexFrame::Array(frames) => {
+      let mut out = Vec::with_capacity(frames.len());
+      for frame in frames.into_iter() {
+        out.push(make_bytes_frame(buf, frame)?);
+      }
+      Resp2Frame::Array(out)
+    }
+  };
+
+  Ok(out)
+}
+
+fn freeze_parse(
+  buf: &mut BytesMut,
+  frame: Resp2IndexFrame,
+  amt: usize,
+) -> Result<(Resp2Frame, usize, Bytes), RedisProtocolError> {
+  if amt > buf.len() {
+    return Err(RedisProtocolError::new(
+      RedisProtocolErrorKind::DecodeError,
+      "Invalid parsed amount > buffer length.",
+    ));
+  }
+
+  let buffer = buf.split_to(amt).freeze();
+  let frame = make_bytes_frame(&buffer, frame)?;
+  Ok((frame, amt, buffer))
+}
+
+/// Attempt to parse the contents of `buf`, returning the first valid frame, the number of bytes consumed, and the frozen consumed bytes.
+///
+/// If the byte slice contains an incomplete frame then `None` is returned.
+///
+/// Unlike `decode` this function works on a mutable `BytesMut` buffer in order to parse frames without copying the inner buffer contents
+/// and will automatically split off the consumed bytes before returning. If an error or `None` is returned the buffer will not be modified.
+pub fn decode_mut(buf: &mut BytesMut) -> Result<Option<(Resp2Frame, usize, Bytes)>, RedisProtocolError> {
+  let (offset, len) = (0, buf.len());
+
+  let (frame, amt) = match d_parse_frame((buf.as_bytes(), offset)) {
+    Ok(((remaining, offset), frame)) => {
+      assert_eq!(offset, len - remaining.len(), "returned offset doesn't match");
+      (frame, offset)
+    }
+    Err(NomErr::Incomplete(_)) => return Ok(None),
+    Err(NomErr::Error(e)) => return Err(e.into()),
+    Err(NomErr::Failure(e)) => return Err(e.into()),
+  };
+  decode_log!(buf, "Decoded frame with amt {}: {:?} from buffer {:?}", amt, frame, buf);
+
+  freeze_parse(buf, frame, amt).map(|r| Some(r))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::resp2::decode::tests::*;
+  use crate::resp2::types::Frame;
+  use nom::AsBytes;
+
+  fn decode_and_verify_some(bytes: &Bytes, expected: &(Option<Frame>, usize)) {
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, len) = match decode_mut(&mut bytes) {
+      Ok(Some((f, l, _))) => (Some(f), l),
+      Ok(None) => return panic_no_decode(),
+      Err(e) => return pretty_print_panic(e),
+    };
+
+    assert_eq!(frame, expected.0, "decoded frame matched");
+    assert_eq!(len, expected.1, "decoded frame len matched");
+  }
+
+  fn decode_and_verify_padded_some(bytes: &Bytes, expected: &(Option<Frame>, usize)) {
+    let mut buf = BytesMut::from(bytes.as_bytes());
+    buf.extend_from_slice(PADDING.as_bytes());
+
+    let (frame, len) = match decode_mut(&mut buf) {
+      Ok(Some((f, l, _))) => (Some(f), l),
+      Ok(None) => return panic_no_decode(),
+      Err(e) => return pretty_print_panic(e),
+    };
+
+    assert_eq!(frame, expected.0, "decoded frame matched");
+    assert_eq!(len, expected.1, "decoded frame len matched");
+  }
+
+  fn decode_and_verify_none(bytes: &Bytes) {
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, len) = match decode_mut(&mut bytes) {
+      Ok(Some((f, l, _))) => (Some(f), l),
+      Ok(None) => (None, 0),
+      Err(e) => return pretty_print_panic(e),
+    };
+
+    assert!(frame.is_none());
+    assert_eq!(len, 0);
+  }
+
+  #[test]
+  fn should_decode_llen_res_example() {
+    let expected = (Some(Frame::Integer(48293)), 8);
+    let bytes: Bytes = ":48293\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_simple_string() {
+    let expected = (Some(Frame::SimpleString("string".into())), 9);
+    let bytes: Bytes = "+string\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_simple_string_incomplete() {
+    let expected = (Some(Frame::SimpleString("string".into())), 9);
+    let bytes: Bytes = "+stri".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_bulk_string() {
+    let expected = (Some(Frame::BulkString("foo".into())), 9);
+    let bytes: Bytes = "$3\r\nfoo\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_bulk_string_incomplete() {
+    let expected = (Some(Frame::BulkString("foo".into())), 9);
+    let bytes: Bytes = "$3\r\nfo".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_array_no_nulls() {
+    let expected = (
+      Some(Frame::Array(vec![
+        Frame::SimpleString("Foo".into()),
+        Frame::SimpleString("Bar".into()),
+      ])),
+      16,
+    );
+    let bytes: Bytes = "*2\r\n+Foo\r\n+Bar\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_array_nulls() {
+    let bytes: Bytes = "*3\r\n$3\r\nFoo\r\n$-1\r\n$3\r\nBar\r\n".into();
+
+    let expected = (
+      Some(Frame::Array(vec![
+        Frame::BulkString("Foo".into()),
+        Frame::Null,
+        Frame::BulkString("Bar".into()),
+      ])),
+      bytes.len(),
+    );
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_normal_error() {
+    let bytes: Bytes = "-WRONGTYPE Operation against a key holding the wrong kind of value\r\n".into();
+    let expected = (
+      Some(Frame::Error(
+        "WRONGTYPE Operation against a key holding the wrong kind of value".into(),
+      )),
+      bytes.len(),
+    );
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_moved_error() {
+    let bytes: Bytes = "-MOVED 3999 127.0.0.1:6381\r\n".into();
+    let expected = (Some(Frame::Error("MOVED 3999 127.0.0.1:6381".into())), bytes.len());
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_ask_error() {
+    let bytes: Bytes = "-ASK 3999 127.0.0.1:6381\r\n".into();
+    let expected = (Some(Frame::Error("ASK 3999 127.0.0.1:6381".into())), bytes.len());
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_incomplete() {
+    let bytes: Bytes = "*3\r\n$3\r\nFoo\r\n$-1\r\n$3\r\nBar".into();
+    decode_and_verify_none(&bytes);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_error_on_junk() {
+    let mut bytes: BytesMut = "foobarbazwibblewobble".into();
+    let _ = decode_mut(&mut bytes).map_err(|e| pretty_print_panic(e));
+  }
+}

--- a/src/decode_mut/resp2.rs
+++ b/src/decode_mut/resp2.rs
@@ -171,7 +171,7 @@ fn d_parse_frame(input: (&[u8], usize)) -> IResult<(&[u8], usize), Resp2IndexFra
   }
 }
 
-fn make_bytes_frame(buf: &Bytes, frame: Resp2IndexFrame) -> Result<Resp2Frame, RedisProtocolError> {
+fn build_bytes_frame(buf: &Bytes, frame: Resp2IndexFrame) -> Result<Resp2Frame, RedisProtocolError> {
   let out = match frame {
     Resp2IndexFrame::Error { start, end } => {
       let bytes = range_to_bytes(buf, start, end)?;
@@ -190,7 +190,7 @@ fn make_bytes_frame(buf: &Bytes, frame: Resp2IndexFrame) -> Result<Resp2Frame, R
     Resp2IndexFrame::Array(frames) => {
       let mut out = Vec::with_capacity(frames.len());
       for frame in frames.into_iter() {
-        out.push(make_bytes_frame(buf, frame)?);
+        out.push(build_bytes_frame(buf, frame)?);
       }
       Resp2Frame::Array(out)
     }
@@ -212,7 +212,7 @@ fn freeze_parse(
   }
 
   let buffer = buf.split_to(amt).freeze();
-  let frame = make_bytes_frame(&buffer, frame)?;
+  let frame = build_bytes_frame(&buffer, frame)?;
   Ok((frame, amt, buffer))
 }
 

--- a/src/decode_mut/resp3.rs
+++ b/src/decode_mut/resp3.rs
@@ -1,12 +1,45 @@
-use crate::decode_mut::frame::{DecodedIndexFrame, IndexAttributes, IndexFrameMap, Resp3IndexFrame};
+use crate::decode_mut::frame::{
+  DResult, DecodedIndexFrame, IndexAttributes, IndexFrameMap, Resp3IndexFrame, StreamedIndexFrame,
+};
 use crate::decode_mut::utils::range_to_bytes;
 use crate::resp3::decode::*;
-use crate::resp3::types::{Attributes, Frame as Resp3Frame};
+use crate::resp3::types::{
+  Attributes, DecodedFrame, Frame as Resp3Frame, FrameKind, StreamedFrame, AUTH, EMPTY_SPACE, HELLO,
+};
 use crate::resp3::utils as resp3_utils;
-use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind};
+use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind, CRLF};
+use crate::utils;
 use bytes::{Bytes, BytesMut};
 use bytes_utils::Str;
+use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
+use nom::combinator::{map as nom_map, map_res as nom_map_res, opt as nom_opt};
+use nom::multi::count as nom_count;
+use nom::number::streaming::be_u8;
+use nom::sequence::terminated as nom_terminated;
+use nom::{AsBytes, Err as NomErr, IResult};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::str;
+
+fn map_hello<'a>(frame: Resp3Frame) -> Result<Resp3IndexFrame, RedisParseError<&'a [u8]>> {
+  match frame {
+    Resp3Frame::Hello { version, auth } => Ok(Resp3IndexFrame::Hello { version, auth }),
+    _ => Err(RedisParseError::new_custom(
+      "map_hello",
+      "Invalid frame, expected HELLO.",
+    )),
+  }
+}
+
+fn map_complete_frame(frame: Resp3IndexFrame) -> DecodedIndexFrame {
+  DecodedIndexFrame::Complete(frame)
+}
+
+fn unwrap_complete_index_frame<'a>(frame: DecodedIndexFrame) -> Result<Resp3IndexFrame, RedisParseError<&'a [u8]>> {
+  frame
+    .into_complete_frame()
+    .map_err(|e| RedisParseError::new_custom("unwrap_complete_frame", format!("{:?}", e)))
+}
 
 fn to_map<'a>(mut data: Vec<Resp3IndexFrame>) -> Result<IndexFrameMap, RedisParseError<&'a [u8]>> {
   if data.len() % 2 != 0 {
@@ -43,13 +76,358 @@ fn attach_attributes<'a>(
   }
 }
 
-//
-//
-//
-//
-//
-//
-//
+fn d_read_to_crlf(input: (&[u8], usize)) -> DResult<usize> {
+  decode_log!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", _input);
+  let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
+  Ok(((input_bytes, input.1 + data.len() + 2), data.len()))
+}
+
+fn d_read_to_crlf_take(input: (&[u8], usize)) -> DResult<&[u8]> {
+  decode_log!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", _input);
+  let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
+  Ok(((input_bytes, input.1 + data.len() + 2), data))
+}
+
+fn d_read_prefix_len(input: (&[u8], usize)) -> DResult<usize> {
+  let ((input, offset), data) = d_read_to_crlf_take(input)?;
+  decode_log!("Reading prefix len. Data: {:?}", str::from_utf8(data));
+  Ok(((input, offset), etry!(to_usize(data))))
+}
+
+fn d_read_prefix_len_signed(input: (&[u8], usize)) -> DResult<isize> {
+  let ((input, offset), data) = d_read_to_crlf_take(input)?;
+  decode_log!("Reading prefix len. Data: {:?}", str::from_utf8(data));
+  Ok(((input, offset), etry!(to_isize(&data))))
+}
+
+fn d_frame_type(input: (&[u8], usize)) -> DResult<FrameKind> {
+  let (input_bytes, byte) = be_u8(input.0)?;
+  let kind = match FrameKind::from_byte(byte) {
+    Some(k) => k,
+    None => e!(RedisParseError::new_custom("frame_type", "Invalid frame type prefix.")),
+  };
+  decode_log!(
+    input_bytes,
+    "Parsed frame type {:?}, remaining: {:?}",
+    kind,
+    input_bytes
+  );
+
+  Ok(((input_bytes, input.1 + 1), kind))
+}
+
+fn d_parse_simplestring(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let offset = input.1;
+  let ((input, next_offset), len) = d_read_to_crlf(input)?;
+  Ok((
+    (input, next_offset),
+    Resp3IndexFrame::SimpleString {
+      data: (offset, offset + len),
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_simpleerror(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let offset = input.1;
+  let ((input, next_offset), len) = d_read_to_crlf(input)?;
+  Ok((
+    (input, next_offset),
+    Resp3IndexFrame::SimpleError {
+      data: (offset, offset + len),
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_number(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
+  let parsed = etry!(to_i64(&data));
+  Ok((
+    (input, next_offset),
+    Resp3IndexFrame::Number {
+      data: parsed,
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_double(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
+  let parsed = etry!(to_f64(&data));
+  Ok((
+    (input, next_offset),
+    Resp3IndexFrame::Double {
+      data: parsed,
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_boolean(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
+  let parsed = etry!(to_bool(&data));
+  Ok((
+    (input, next_offset),
+    Resp3IndexFrame::Boolean {
+      data: parsed,
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_null(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let ((input, next_offset), _) = d_read_to_crlf(input)?;
+  Ok(((input, next_offset), Resp3IndexFrame::Null))
+}
+
+fn d_parse_blobstring(input: (&[u8], usize), len: usize) -> DResult<Resp3IndexFrame> {
+  let offset = input.1;
+  let (input, data) = nom_terminated(nom_take(len), nom_take(2_usize))(input.0)?;
+
+  Ok((
+    (input, offset + len + 2),
+    Resp3IndexFrame::BlobString {
+      data: (offset, offset + data.len()),
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_bloberror(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let ((input, offset), len) = d_read_prefix_len(input)?;
+  let (input, data) = nom_terminated(nom_take(len), nom_take(2_usize))(input)?;
+
+  Ok((
+    (input, offset + len + 2),
+    Resp3IndexFrame::BlobError {
+      data: (offset, offset + data.len()),
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_verbatimstring(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let ((input, prefix_offset), len) = d_read_prefix_len(input)?;
+  let (input, format_bytes) = nom_terminated(nom_take(3_usize), nom_take(1_usize))(input)?;
+  let format = etry!(to_verbatimstring_format(&format_bytes));
+  let (input, _) = nom_terminated(nom_take(len - 4), nom_take(2_usize))(input)?;
+
+  Ok((
+    (input, prefix_offset + len + 2),
+    Resp3IndexFrame::VerbatimString {
+      data: (prefix_offset + 4, prefix_offset + len),
+      format,
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_bignumber(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let offset = input.1;
+  let ((input, next_offset), len) = d_read_to_crlf(input)?;
+
+  Ok((
+    (input, next_offset),
+    Resp3IndexFrame::BigNumber {
+      data: (offset, offset + len),
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_array_frames(input: (&[u8], usize), len: usize) -> DResult<Vec<Resp3IndexFrame>> {
+  nom_count(
+    nom_map_res(d_parse_frame_or_attribute, unwrap_complete_index_frame),
+    len,
+  )(input)
+}
+
+fn d_parse_kv_pairs(input: (&[u8], usize), len: usize) -> DResult<IndexFrameMap> {
+  nom_map_res(
+    nom_count(
+      nom_map_res(d_parse_frame_or_attribute, unwrap_complete_index_frame),
+      len * 2,
+    ),
+    to_map,
+  )(input)
+}
+
+fn d_parse_array(input: (&[u8], usize), len: usize) -> DResult<Resp3IndexFrame> {
+  let (input, data) = d_parse_array_frames(input, len)?;
+  Ok((input, Resp3IndexFrame::Array { data, attributes: None }))
+}
+
+fn d_parse_push(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let (input, len) = d_read_prefix_len(input)?;
+  let (input, data) = d_parse_array_frames(input, len)?;
+  Ok((input, Resp3IndexFrame::Push { data, attributes: None }))
+}
+
+fn d_parse_set(input: (&[u8], usize), len: usize) -> DResult<Resp3IndexFrame> {
+  let (input, frames) = d_parse_array_frames(input, len)?;
+  let set = etry!(to_set(frames));
+
+  Ok((
+    input,
+    Resp3IndexFrame::Set {
+      data: set,
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_map(input: (&[u8], usize), len: usize) -> DResult<Resp3IndexFrame> {
+  let (input, frames) = d_parse_kv_pairs(input, len)?;
+
+  Ok((
+    input,
+    Resp3IndexFrame::Map {
+      data: frames,
+      attributes: None,
+    },
+  ))
+}
+
+fn d_parse_attribute(input: (&[u8], usize)) -> DResult<IndexFrameMap> {
+  let (input, len) = d_read_prefix_len(input)?;
+  let (input, attributes) = d_parse_kv_pairs(input, len)?;
+  Ok((input, attributes))
+}
+
+fn d_parse_hello(input: (&[u8], usize)) -> DResult<Resp3IndexFrame> {
+  let mut offset = input.1;
+  let (input, _) = nom_map_res(
+    nom_terminated(nom_take_until(HELLO.as_bytes()), nom_take(1_usize)),
+    str::from_utf8,
+  )(input.0)?;
+  offset += HELLO.as_bytes().len() + 1;
+
+  let (input, version) = be_u8(input)?;
+  offset += 1;
+
+  let (input, auth) = nom_opt(nom_map_res(
+    nom_terminated(nom_take_until(AUTH.as_bytes()), nom_take(1_usize)),
+    str::from_utf8,
+  ))(input)?;
+
+  let (input, auth) = if auth.is_some() {
+    offset += AUTH.as_bytes().len() + 1;
+
+    let (input, username) = nom_map_res(
+      nom_terminated(nom_take_until(EMPTY_SPACE.as_bytes()), nom_take(1_usize)),
+      str::from_utf8,
+    )(input)?;
+    let (input, password) = nom_map_res(nom_take_until(CRLF.as_bytes()), str::from_utf8)(input)?;
+    offset += username.as_bytes().len() + password.as_bytes().len() + 1 + 2;
+
+    (input, Some((Str::from(username), Str::from(password))))
+  } else {
+    (input, None)
+  };
+
+  let hello = etry!(to_hello(version, auth));
+  Ok(((input, offset), etry!(map_hello(hello))))
+}
+
+/// Check for a streaming variant of a frame, and if found then return the prefix bytes only, otherwise return the complete frame.
+///
+/// Only supported for arrays, sets, maps, and blob strings.
+fn d_check_streaming(input: (&[u8], usize), kind: FrameKind) -> DResult<DecodedIndexFrame> {
+  let (input, len) = d_read_prefix_len_signed(input)?;
+  let (input, frame) = if len == -1 {
+    (input, DecodedIndexFrame::Streaming(StreamedIndexFrame::new(kind)))
+  } else {
+    let len = etry!(isize_to_usize(len));
+    let (input, frame) = match kind {
+      FrameKind::Array => d_parse_array(input, len)?,
+      FrameKind::Set => d_parse_set(input, len)?,
+      FrameKind::Map => d_parse_map(input, len)?,
+      FrameKind::BlobString => d_parse_blobstring(input, len)?,
+      _ => e!(RedisParseError::new_custom(
+        "check_streaming",
+        format!("Invalid frame type: {:?}", kind)
+      )),
+    };
+
+    (input, DecodedIndexFrame::Complete(frame))
+  };
+
+  Ok((input, frame))
+}
+
+fn d_parse_chunked_string(input: (&[u8], usize)) -> DResult<DecodedIndexFrame> {
+  let (input, len) = d_read_prefix_len(input)?;
+  let (input, frame) = if len == 0 {
+    (input, Resp3IndexFrame::new_end_stream())
+  } else {
+    let offset = input.1;
+    let (input, contents) = nom_terminated(nom_take(len), nom_take(2_usize))(input.0)?;
+
+    (
+      (input, offset + contents.len() + 2),
+      Resp3IndexFrame::ChunkedString((offset, offset + len)),
+    )
+  };
+
+  Ok((input, DecodedIndexFrame::Complete(frame)))
+}
+
+fn d_return_end_stream(input: (&[u8], usize)) -> DResult<DecodedIndexFrame> {
+  let (input, _) = d_read_to_crlf(input)?;
+  Ok((input, DecodedIndexFrame::Complete(Resp3IndexFrame::new_end_stream())))
+}
+
+fn d_parse_non_attribute_frame(input: (&[u8], usize), kind: FrameKind) -> DResult<DecodedIndexFrame> {
+  let (input, frame) = match kind {
+    FrameKind::Array => d_check_streaming(input, kind)?,
+    FrameKind::BlobString => d_check_streaming(input, kind)?,
+    FrameKind::Map => d_check_streaming(input, kind)?,
+    FrameKind::Set => d_check_streaming(input, kind)?,
+    FrameKind::SimpleString => nom_map(d_parse_simplestring, map_complete_frame)(input)?,
+    FrameKind::SimpleError => nom_map(d_parse_simpleerror, map_complete_frame)(input)?,
+    FrameKind::Number => nom_map(d_parse_number, map_complete_frame)(input)?,
+    FrameKind::Null => nom_map(d_parse_null, map_complete_frame)(input)?,
+    FrameKind::Double => nom_map(d_parse_double, map_complete_frame)(input)?,
+    FrameKind::Boolean => nom_map(d_parse_boolean, map_complete_frame)(input)?,
+    FrameKind::BlobError => nom_map(d_parse_bloberror, map_complete_frame)(input)?,
+    FrameKind::VerbatimString => nom_map(d_parse_verbatimstring, map_complete_frame)(input)?,
+    FrameKind::Push => nom_map(d_parse_push, map_complete_frame)(input)?,
+    FrameKind::BigNumber => nom_map(d_parse_bignumber, map_complete_frame)(input)?,
+    FrameKind::Hello => nom_map(d_parse_hello, map_complete_frame)(input)?,
+    FrameKind::ChunkedString => d_parse_chunked_string(input)?,
+    FrameKind::EndStream => d_return_end_stream(input)?,
+    FrameKind::Attribute => {
+      error!("Found unexpected attribute frame.");
+      e!(RedisParseError::new_custom(
+        "parse_non_attribute_frame",
+        "Unexpected attribute frame.",
+      ));
+    }
+  };
+
+  Ok((input, frame))
+}
+
+fn d_parse_attribute_and_frame(input: (&[u8], usize)) -> DResult<DecodedIndexFrame> {
+  let (input, attributes) = d_parse_attribute(input)?;
+  let (input, kind) = d_frame_type(input)?;
+  let (input, next_frame) = d_parse_non_attribute_frame(input, kind)?;
+  let frame = etry!(attach_attributes(attributes, next_frame));
+
+  Ok((input, frame))
+}
+
+fn d_parse_frame_or_attribute(input: (&[u8], usize)) -> DResult<DecodedIndexFrame> {
+  let (input, kind) = d_frame_type(input)?;
+  let (input, frame) = if let FrameKind::Attribute = kind {
+    d_parse_attribute_and_frame(input)?
+  } else {
+    d_parse_non_attribute_frame(input, kind)?
+  };
+
+  Ok((input, frame))
+}
 
 fn build_attributes(buf: &Bytes, attributes: IndexAttributes) -> Result<Option<Attributes>, RedisProtocolError> {
   if let Some(attributes) = attributes {
@@ -164,11 +542,27 @@ fn build_bytes_frame(buf: &Bytes, frame: Resp3IndexFrame) -> Result<Resp3Frame, 
   Ok(out)
 }
 
+fn build_bytes_decoded_frame(buf: &Bytes, frame: DecodedIndexFrame) -> Result<DecodedFrame, RedisProtocolError> {
+  let out = match frame {
+    DecodedIndexFrame::Streaming(streaming) => {
+      let mut frame = StreamedFrame::new(streaming.kind);
+      frame.attributes = build_attributes(buf, streaming.attributes)?;
+      DecodedFrame::Streaming(frame)
+    }
+    DecodedIndexFrame::Complete(frame) => {
+      let frame = build_bytes_frame(buf, frame)?;
+      DecodedFrame::Complete(frame)
+    }
+  };
+
+  Ok(out)
+}
+
 fn freeze_parse(
   buf: &mut BytesMut,
-  frame: Resp3IndexFrame,
+  frame: DecodedIndexFrame,
   amt: usize,
-) -> Result<(Resp3Frame, usize, Bytes), RedisProtocolError> {
+) -> Result<(DecodedFrame, usize, Bytes), RedisProtocolError> {
   if amt > buf.len() {
     return Err(RedisProtocolError::new(
       RedisProtocolErrorKind::DecodeError,
@@ -177,7 +571,7 @@ fn freeze_parse(
   }
 
   let buffer = buf.split_to(amt).freeze();
-  let frame = build_bytes_frame(&buffer, frame)?;
+  let frame = build_bytes_decoded_frame(&buffer, frame)?;
   Ok((frame, amt, buffer))
 }
 
@@ -191,7 +585,23 @@ pub mod complete {
   /// Unlike `decode` this function works on a mutable `BytesMut` buffer in order to parse frames without copying the inner buffer contents
   /// and will automatically split off the consumed bytes before returning. If an error or `None` is returned the buffer will not be modified.
   pub fn decode_mut(buf: &mut BytesMut) -> Result<Option<(Resp3Frame, usize, Bytes)>, RedisProtocolError> {
-    unimplemented!()
+    let (offset, len) = (0, buf.len());
+
+    let (frame, amt) = match d_parse_frame_or_attribute((buf.as_bytes(), offset)) {
+      Ok(((remaining, offset), frame)) => {
+        assert_eq!(offset, len - remaining.len(), "returned offset doesn't match");
+        (frame, offset)
+      }
+      Err(NomErr::Incomplete(_)) => return Ok(None),
+      Err(NomErr::Error(e)) => return Err(e.into()),
+      Err(NomErr::Failure(e)) => return Err(e.into()),
+    };
+    decode_log!(buf, "Decoded frame with amt {}: {:?} from buffer {:?}", amt, frame, buf);
+
+    freeze_parse(buf, frame, amt).and_then(|(frame, amt, buf)| {
+      let frame = unwrap_complete_frame(frame)?;
+      Ok(Some((frame, amt, buf)))
+    })
   }
 }
 
@@ -206,6 +616,1110 @@ pub mod streaming {
   /// Unlike `decode` this function works on a mutable `BytesMut` buffer in order to parse frames without copying the inner buffer contents
   /// and will automatically split off the consumed bytes before returning. If an error or `None` is returned the buffer will not be modified.
   pub fn decode_mut(buf: &mut BytesMut) -> Result<Option<(DecodedFrame, usize, Bytes)>, RedisProtocolError> {
-    unimplemented!()
+    let (offset, len) = (0, buf.len());
+
+    let (frame, amt) = match d_parse_frame_or_attribute((buf.as_bytes(), offset)) {
+      Ok(((remaining, offset), frame)) => {
+        assert_eq!(offset, len - remaining.len(), "returned offset doesn't match");
+        (frame, offset)
+      }
+      Err(NomErr::Incomplete(_)) => return Ok(None),
+      Err(NomErr::Error(e)) => return Err(e.into()),
+      Err(NomErr::Failure(e)) => return Err(e.into()),
+    };
+    decode_log!(buf, "Decoded frame with amt {}: {:?} from buffer {:?}", amt, frame, buf);
+
+    freeze_parse(buf, frame, amt).map(|r| Some(r))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::decode_mut::resp3::complete::decode_mut;
+  use crate::decode_mut::resp3::streaming::decode_mut as stream_decode_mut;
+  use crate::resp3::decode::tests::*;
+  use crate::resp3::types::{Frame, VerbatimStringFormat};
+  use bytes::{Bytes, BytesMut};
+  use std::str;
+
+  fn decode_and_verify_some(bytes: &Bytes, expected: &(Option<Frame>, usize)) {
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, len) = match decode_mut(&mut bytes) {
+      Ok(Some((f, l, _))) => (Some(f), l),
+      Ok(None) => return panic_no_decode(),
+      Err(e) => return pretty_print_panic(e),
+    };
+
+    assert_eq!(frame, expected.0, "decoded frame matched");
+    assert_eq!(len, expected.1, "decoded frame len matched");
+  }
+
+  fn decode_and_verify_padded_some(bytes: &Bytes, expected: &(Option<Frame>, usize)) {
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    bytes.extend_from_slice(PADDING.as_bytes());
+
+    let (frame, len) = match decode_mut(&mut bytes) {
+      Ok(Some((f, l, _))) => (Some(f), l),
+      Ok(None) => return panic_no_decode(),
+      Err(e) => return pretty_print_panic(e),
+    };
+
+    assert_eq!(frame, expected.0, "decoded frame matched");
+    assert_eq!(len, expected.1, "decoded frame len matched");
+  }
+
+  fn decode_and_verify_none(bytes: &Bytes) {
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, len) = match decode_mut(&mut bytes) {
+      Ok(Some((f, l, _))) => (Some(f), l),
+      Ok(None) => (None, 0),
+      Err(e) => return pretty_print_panic(e),
+    };
+
+    assert!(frame.is_none());
+    assert_eq!(len, 0);
+  }
+
+  #[test]
+  fn should_decode_llen_res_example() {
+    let expected = (
+      Some(Frame::Number {
+        data: 48293,
+        attributes: None,
+      }),
+      8,
+    );
+    let bytes: Bytes = ":48293\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_simple_string() {
+    let expected = (
+      Some(Frame::SimpleString {
+        data: "string".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "+string\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_simple_string_incomplete() {
+    let expected = (
+      Some(Frame::SimpleString {
+        data: "string".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "+stri".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_blob_string() {
+    let expected = (
+      Some(Frame::BlobString {
+        data: "foo".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "$3\r\nfoo\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_blob_string_incomplete() {
+    let expected = (
+      Some(Frame::BlobString {
+        data: "foo".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "$3\r\nfo".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_array_no_nulls() {
+    let expected = (
+      Some(Frame::Array {
+        data: vec![
+          Frame::SimpleString {
+            data: "Foo".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "Bar".into(),
+            attributes: None,
+          },
+        ],
+        attributes: None,
+      }),
+      16,
+    );
+    let bytes: Bytes = "*2\r\n+Foo\r\n+Bar\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_array_nulls() {
+    let bytes: Bytes = "*3\r\n$3\r\nFoo\r\n_\r\n$3\r\nBar\r\n".into();
+
+    let expected = (
+      Some(Frame::Array {
+        data: vec![
+          Frame::BlobString {
+            data: "Foo".into(),
+            attributes: None,
+          },
+          Frame::Null,
+          Frame::BlobString {
+            data: "Bar".into(),
+            attributes: None,
+          },
+        ],
+        attributes: None,
+      }),
+      bytes.len(),
+    );
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_normal_error() {
+    let bytes: Bytes = "-WRONGTYPE Operation against a key holding the wrong kind of value\r\n".into();
+    let expected = (
+      Some(Frame::SimpleError {
+        data: "WRONGTYPE Operation against a key holding the wrong kind of value".into(),
+        attributes: None,
+      }),
+      bytes.len(),
+    );
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_moved_error() {
+    let bytes: Bytes = "-MOVED 3999 127.0.0.1:6381\r\n".into();
+    let expected = (
+      Some(Frame::SimpleError {
+        data: "MOVED 3999 127.0.0.1:6381".into(),
+        attributes: None,
+      }),
+      bytes.len(),
+    );
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_ask_error() {
+    let bytes: Bytes = "-ASK 3999 127.0.0.1:6381\r\n".into();
+    let expected = (
+      Some(Frame::SimpleError {
+        data: "ASK 3999 127.0.0.1:6381".into(),
+        attributes: None,
+      }),
+      bytes.len(),
+    );
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_incomplete() {
+    let bytes: Bytes = "*3\r\n$3\r\nFoo\r\n_\r\n$3\r\nBar".into();
+    decode_and_verify_none(&bytes);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_error_on_junk() {
+    let mut bytes: BytesMut = "foobarbazwibblewobble".into();
+    let _ = complete::decode_mut(&mut bytes).map_err(|e| pretty_print_panic(e));
+  }
+
+  // ----------------- end tests adapted from RESP2 ------------------------
+
+  #[test]
+  fn should_decode_blob_error() {
+    let expected = (
+      Some(Frame::BlobError {
+        data: "foo".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "!3\r\nfoo\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_blob_error_incomplete() {
+    let expected = (
+      Some(Frame::BlobError {
+        data: "foo".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "!3\r\nfo".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_simple_error() {
+    let expected = (
+      Some(Frame::SimpleError {
+        data: "string".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "-string\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_simple_error_incomplete() {
+    let expected = (
+      Some(Frame::SimpleError {
+        data: "string".into(),
+        attributes: None,
+      }),
+      9,
+    );
+    let bytes: Bytes = "-strin".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_boolean_true() {
+    let expected = (
+      Some(Frame::Boolean {
+        data: true,
+        attributes: None,
+      }),
+      4,
+    );
+    let bytes: Bytes = "#t\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_boolean_false() {
+    let expected = (
+      Some(Frame::Boolean {
+        data: false,
+        attributes: None,
+      }),
+      4,
+    );
+    let bytes: Bytes = "#f\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_number() {
+    let expected = (
+      Some(Frame::Number {
+        data: 42,
+        attributes: None,
+      }),
+      5,
+    );
+    let bytes: Bytes = ":42\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_double_inf() {
+    let expected = (
+      Some(Frame::Double {
+        data: f64::INFINITY,
+        attributes: None,
+      }),
+      6,
+    );
+    let bytes: Bytes = ",inf\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_double_neg_inf() {
+    let expected = (
+      Some(Frame::Double {
+        data: f64::NEG_INFINITY,
+        attributes: None,
+      }),
+      7,
+    );
+    let bytes: Bytes = ",-inf\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  #[should_panic]
+  fn should_decode_double_nan() {
+    let expected = (
+      Some(Frame::Double {
+        data: f64::NAN,
+        attributes: None,
+      }),
+      7,
+    );
+    let bytes: Bytes = ",foo\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_double() {
+    let expected = (
+      Some(Frame::Double {
+        data: 4.59193,
+        attributes: None,
+      }),
+      10,
+    );
+    let bytes: Bytes = ",4.59193\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+
+    let expected = (
+      Some(Frame::Double {
+        data: 4_f64,
+        attributes: None,
+      }),
+      4,
+    );
+    let bytes: Bytes = ",4\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_bignumber() {
+    let expected = (
+      Some(Frame::BigNumber {
+        data: "3492890328409238509324850943850943825024385".into(),
+        attributes: None,
+      }),
+      46,
+    );
+    let bytes: Bytes = "(3492890328409238509324850943850943825024385\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_null() {
+    let expected = (Some(Frame::Null), 3);
+    let bytes: Bytes = "_\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_verbatim_string_mkd() {
+    let expected = (
+      Some(Frame::VerbatimString {
+        data: "Some string".into(),
+        format: VerbatimStringFormat::Markdown,
+        attributes: None,
+      }),
+      22,
+    );
+    let bytes: Bytes = "=15\r\nmkd:Some string\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_verbatim_string_txt() {
+    let expected = (
+      Some(Frame::VerbatimString {
+        data: "Some string".into(),
+        format: VerbatimStringFormat::Text,
+        attributes: None,
+      }),
+      22,
+    );
+    let bytes: Bytes = "=15\r\ntxt:Some string\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_map_no_nulls() {
+    let k1 = Frame::SimpleString {
+      data: "first".into(),
+      attributes: None,
+    };
+    let v1 = Frame::Number {
+      data: 1,
+      attributes: None,
+    };
+    let k2 = Frame::BlobString {
+      data: "second".into(),
+      attributes: None,
+    };
+    let v2 = Frame::Double {
+      data: 4.2,
+      attributes: None,
+    };
+
+    let mut expected_map = resp3_utils::new_map(None);
+    expected_map.insert(k1, v1);
+    expected_map.insert(k2, v2);
+    let expected = (
+      Some(Frame::Map {
+        data: expected_map,
+        attributes: None,
+      }),
+      34,
+    );
+    let bytes: Bytes = "%2\r\n+first\r\n:1\r\n$6\r\nsecond\r\n,4.2\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_map_with_nulls() {
+    let k1 = Frame::SimpleString {
+      data: "first".into(),
+      attributes: None,
+    };
+    let v1 = Frame::Number {
+      data: 1,
+      attributes: None,
+    };
+    let k2 = Frame::Number {
+      data: 2,
+      attributes: None,
+    };
+    let v2 = Frame::Null;
+    let k3 = Frame::BlobString {
+      data: "second".into(),
+      attributes: None,
+    };
+    let v3 = Frame::Double {
+      data: 4.2,
+      attributes: None,
+    };
+
+    let mut expected_map = resp3_utils::new_map(None);
+    expected_map.insert(k1, v1);
+    expected_map.insert(k2, v2);
+    expected_map.insert(k3, v3);
+    let expected = (
+      Some(Frame::Map {
+        data: expected_map,
+        attributes: None,
+      }),
+      41,
+    );
+    let bytes: Bytes = "%3\r\n+first\r\n:1\r\n:2\r\n_\r\n$6\r\nsecond\r\n,4.2\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_set_no_nulls() {
+    let mut expected_set = resp3_utils::new_set(None);
+    expected_set.insert(Frame::Number {
+      data: 1,
+      attributes: None,
+    });
+    expected_set.insert(Frame::SimpleString {
+      data: "2".into(),
+      attributes: None,
+    });
+    expected_set.insert(Frame::BlobString {
+      data: "foobar".into(),
+      attributes: None,
+    });
+    expected_set.insert(Frame::Double {
+      data: 4.2,
+      attributes: None,
+    });
+    let expected = (
+      Some(Frame::Set {
+        data: expected_set,
+        attributes: None,
+      }),
+      30,
+    );
+    let bytes: Bytes = "~4\r\n:1\r\n+2\r\n$6\r\nfoobar\r\n,4.2\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_set_with_nulls() {
+    let mut expected_set = resp3_utils::new_set(None);
+    expected_set.insert(Frame::Number {
+      data: 1,
+      attributes: None,
+    });
+    expected_set.insert(Frame::SimpleString {
+      data: "2".into(),
+      attributes: None,
+    });
+    expected_set.insert(Frame::Null);
+    expected_set.insert(Frame::Double {
+      data: 4.2,
+      attributes: None,
+    });
+    let expected = (
+      Some(Frame::Set {
+        data: expected_set,
+        attributes: None,
+      }),
+      21,
+    );
+    let bytes: Bytes = "~4\r\n:1\r\n+2\r\n_\r\n,4.2\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_push_pubsub() {
+    let expected = (
+      Some(Frame::Push {
+        data: vec![
+          Frame::SimpleString {
+            data: "pubsub".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "message".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "somechannel".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "this is the message".into(),
+            attributes: None,
+          },
+        ],
+        attributes: None,
+      }),
+      59,
+    );
+    let bytes: Bytes = ">4\r\n+pubsub\r\n+message\r\n+somechannel\r\n+this is the message\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, _, _) = decode_mut(&mut bytes).unwrap().unwrap();
+    assert!(frame.is_pubsub_message());
+    assert!(frame.is_normal_pubsub());
+  }
+
+  #[test]
+  fn should_decode_push_pattern_pubsub() {
+    let expected = (
+      Some(Frame::Push {
+        data: vec![
+          Frame::SimpleString {
+            data: "pubsub".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "pmessage".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "somechannel".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "this is the message".into(),
+            attributes: None,
+          },
+        ],
+        attributes: None,
+      }),
+      60,
+    );
+    let bytes: Bytes = ">4\r\n+pubsub\r\n+pmessage\r\n+somechannel\r\n+this is the message\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, _, _) = decode_mut(&mut bytes).unwrap().unwrap();
+    assert!(frame.is_pattern_pubsub_message());
+    assert!(frame.is_pubsub_message());
+  }
+
+  #[test]
+  fn should_decode_keyevent_message() {
+    let expected = (
+      Some(Frame::Push {
+        data: vec![
+          Frame::SimpleString {
+            data: "pubsub".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "pmessage".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "__key*".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "__keyevent@0__:set".into(),
+            attributes: None,
+          },
+          Frame::SimpleString {
+            data: "foo".into(),
+            attributes: None,
+          },
+        ],
+        attributes: None,
+      }),
+      60,
+    );
+    let bytes: Bytes = ">5\r\n+pubsub\r\n+pmessage\r\n+__key*\r\n+__keyevent@0__:set\r\n+foo\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+
+    let mut bytes = BytesMut::from(bytes.as_bytes());
+    let (frame, _, _) = decode_mut(&mut bytes).unwrap().unwrap();
+    assert!(frame.is_pattern_pubsub_message());
+    assert!(frame.is_pubsub_message());
+  }
+
+  #[test]
+  fn should_parse_outer_attributes() {
+    let mut expected_inner_attrs = resp3_utils::new_map(None);
+    expected_inner_attrs.insert(
+      Frame::BlobString {
+        data: "a".into(),
+        attributes: None,
+      },
+      Frame::Double {
+        data: 0.1923,
+        attributes: None,
+      },
+    );
+    expected_inner_attrs.insert(
+      Frame::BlobString {
+        data: "b".into(),
+        attributes: None,
+      },
+      Frame::Double {
+        data: 0.0012,
+        attributes: None,
+      },
+    );
+    let expected_inner_attrs = Frame::Map {
+      data: expected_inner_attrs,
+      attributes: None,
+    };
+
+    let mut expected_attrs = resp3_utils::new_map(None);
+    expected_attrs.insert(
+      Frame::SimpleString {
+        data: "key-popularity".into(),
+        attributes: None,
+      },
+      expected_inner_attrs,
+    );
+
+    let expected = (
+      Some(Frame::Array {
+        data: vec![
+          Frame::Number {
+            data: 2039123,
+            attributes: None,
+          },
+          Frame::Number {
+            data: 9543892,
+            attributes: None,
+          },
+        ],
+        attributes: Some(expected_attrs.into()),
+      }),
+      81,
+    );
+
+    let bytes: Bytes =
+      "|1\r\n+key-popularity\r\n%2\r\n$1\r\na\r\n,0.1923\r\n$1\r\nb\r\n,0.0012\r\n*2\r\n:2039123\r\n:9543892\r\n"
+        .into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_parse_inner_attributes() {
+    let mut expected_attrs = resp3_utils::new_map(None);
+    expected_attrs.insert(
+      Frame::SimpleString {
+        data: "ttl".into(),
+        attributes: None,
+      },
+      Frame::Number {
+        data: 3600,
+        attributes: None,
+      },
+    );
+
+    let expected = (
+      Some(Frame::Array {
+        data: vec![
+          Frame::Number {
+            data: 1,
+            attributes: None,
+          },
+          Frame::Number {
+            data: 2,
+            attributes: None,
+          },
+          Frame::Number {
+            data: 3,
+            attributes: Some(expected_attrs),
+          },
+        ],
+        attributes: None,
+      }),
+      33,
+    );
+    let bytes: Bytes = "*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n".into();
+
+    decode_and_verify_some(&bytes, &expected);
+    decode_and_verify_padded_some(&bytes, &expected);
+  }
+
+  #[test]
+  fn should_decode_end_stream() {
+    let mut bytes: BytesMut = ";0\r\n".into();
+    let (frame, _, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::new_end_stream()))
+  }
+
+  #[test]
+  fn should_decode_streaming_string() {
+    let mut bytes: BytesMut = "$?\r\n;4\r\nHell\r\n;6\r\no worl\r\n;1\r\nd\r\n;0\r\n".into();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Streaming(StreamedFrame::new(FrameKind::BlobString))
+    );
+    assert_eq!(amt, 4);
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::ChunkedString("Hell".into())));
+    assert_eq!(amt, 10);
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::ChunkedString("o worl".into())));
+    assert_eq!(amt, 12);
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::ChunkedString("d".into())));
+    assert_eq!(amt, 7);
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::new_end_stream()));
+    assert_eq!(amt, 4);
+  }
+
+  #[test]
+  fn should_decode_streaming_array() {
+    let mut bytes: BytesMut = "*?\r\n:1\r\n:2\r\n:3\r\n.\r\n".into();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Streaming(StreamedFrame::new(FrameKind::Array)));
+    assert_eq!(amt, 4);
+    let mut streamed = frame.into_streaming_frame().unwrap();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 1,
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 2,
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 3,
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::new_end_stream()));
+    assert_eq!(amt, 3);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    assert!(streamed.is_finished());
+    let actual = streamed.into_frame().unwrap();
+    let expected = Frame::Array {
+      data: vec![
+        Frame::Number {
+          data: 1,
+          attributes: None,
+        },
+        Frame::Number {
+          data: 2,
+          attributes: None,
+        },
+        Frame::Number {
+          data: 3,
+          attributes: None,
+        },
+      ],
+      attributes: None,
+    };
+
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn should_decode_streaming_set() {
+    let mut bytes: BytesMut = "~?\r\n:1\r\n:2\r\n:3\r\n.\r\n".into();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Streaming(StreamedFrame::new(FrameKind::Set)));
+    assert_eq!(amt, 4);
+    let mut streamed = frame.into_streaming_frame().unwrap();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 1,
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 2,
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 3,
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::new_end_stream()));
+    assert_eq!(amt, 3);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    assert!(streamed.is_finished());
+    let actual = streamed.into_frame().unwrap();
+    let mut expected_result = resp3_utils::new_set(None);
+    expected_result.insert(Frame::Number {
+      data: 1,
+      attributes: None,
+    });
+    expected_result.insert(Frame::Number {
+      data: 2,
+      attributes: None,
+    });
+    expected_result.insert(Frame::Number {
+      data: 3,
+      attributes: None,
+    });
+
+    let expected = Frame::Set {
+      data: expected_result,
+      attributes: None,
+    };
+
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn should_decode_streaming_map() {
+    let mut bytes: BytesMut = "%?\r\n+a\r\n:1\r\n+b\r\n:2\r\n.\r\n".into();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Streaming(StreamedFrame::new(FrameKind::Map)));
+    assert_eq!(amt, 4);
+    let mut streamed = frame.into_streaming_frame().unwrap();
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::SimpleString {
+        data: "a".into(),
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 1.into(),
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::SimpleString {
+        data: "b".into(),
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(
+      frame,
+      DecodedFrame::Complete(Frame::Number {
+        data: 2.into(),
+        attributes: None
+      })
+    );
+    assert_eq!(amt, 4);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    let (frame, amt, _) = stream_decode_mut(&mut bytes).unwrap().unwrap();
+    assert_eq!(frame, DecodedFrame::Complete(Frame::new_end_stream()));
+    assert_eq!(amt, 3);
+    streamed.add_frame(frame.into_complete_frame().unwrap());
+
+    assert!(streamed.is_finished());
+    let actual = streamed.into_frame().unwrap();
+    let mut expected_result = resp3_utils::new_map(None);
+    expected_result.insert(
+      Frame::SimpleString {
+        data: "a".into(),
+        attributes: None,
+      },
+      Frame::Number {
+        data: 1,
+        attributes: None,
+      },
+    );
+    expected_result.insert(
+      Frame::SimpleString {
+        data: "b".into(),
+        attributes: None,
+      },
+      Frame::Number {
+        data: 2,
+        attributes: None,
+      },
+    );
+    let expected = Frame::Map {
+      data: expected_result,
+      attributes: None,
+    };
+
+    assert_eq!(actual, expected);
   }
 }

--- a/src/decode_mut/resp3.rs
+++ b/src/decode_mut/resp3.rs
@@ -1,55 +1,110 @@
-use crate::decode_mut::frame::Resp3IndexFrame;
+use crate::decode_mut::frame::{DecodedIndexFrame, IndexAttributes, IndexFrameMap, Resp3IndexFrame};
 use crate::decode_mut::utils::range_to_bytes;
+use crate::resp3::decode::*;
 use crate::resp3::types::{Attributes, Frame as Resp3Frame};
 use crate::resp3::utils as resp3_utils;
-use crate::types::{RedisProtocolError, RedisProtocolErrorKind};
+use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind};
 use bytes::{Bytes, BytesMut};
 use bytes_utils::Str;
+use std::collections::{HashMap, HashSet};
 
-fn parse_as_attributes(buf: &Bytes, range: Option<(usize, usize)>) -> Result<Option<Attributes>, RedisProtocolError> {
-  unimplemented!()
+fn to_map<'a>(mut data: Vec<Resp3IndexFrame>) -> Result<IndexFrameMap, RedisParseError<&'a [u8]>> {
+  if data.len() % 2 != 0 {
+    return Err(RedisParseError::new_custom("to_map", "Invalid hashmap frame length."));
+  }
+
+  let mut out = HashMap::with_capacity(data.len() / 2);
+  while data.len() >= 2 {
+    let value = data.pop().unwrap();
+    let key = data.pop().unwrap();
+
+    out.insert(key, value);
+  }
+
+  Ok(out)
 }
-// TODO reconsider storing attributes this way. they're already a map, so maybe make a FrameIndexMap and parse that...
 
-fn make_bytes_frame(buf: &Bytes, frame: Resp3IndexFrame) -> Result<Resp3Frame, RedisProtocolError> {
+fn to_set<'a>(data: Vec<Resp3IndexFrame>) -> Result<HashSet<Resp3IndexFrame>, RedisParseError<&'a [u8]>> {
+  let mut out = HashSet::with_capacity(data.len());
+  for frame in data.into_iter() {
+    out.insert(frame);
+  }
+  Ok(out)
+}
+
+fn attach_attributes<'a>(
+  attributes: IndexFrameMap,
+  mut frame: DecodedIndexFrame,
+) -> Result<DecodedIndexFrame, RedisParseError<&'a [u8]>> {
+  if let Err(e) = frame.add_attributes(attributes) {
+    Err(RedisParseError::new_custom("attach_attributes", format!("{:?}", e)))
+  } else {
+    Ok(frame)
+  }
+}
+
+//
+//
+//
+//
+//
+//
+//
+
+fn build_attributes(buf: &Bytes, attributes: IndexAttributes) -> Result<Option<Attributes>, RedisProtocolError> {
+  if let Some(attributes) = attributes {
+    let mut out = resp3_utils::new_map(Some(attributes.len()));
+    for (key, value) in attributes.into_iter() {
+      let key = build_bytes_frame(buf, key)?;
+      let value = build_bytes_frame(buf, value)?;
+      out.insert(key, value);
+    }
+
+    Ok(Some(out))
+  } else {
+    Ok(None)
+  }
+}
+
+fn build_bytes_frame(buf: &Bytes, frame: Resp3IndexFrame) -> Result<Resp3Frame, RedisProtocolError> {
   let out = match frame {
     Resp3IndexFrame::SimpleString { data, attributes } => {
       let data = range_to_bytes(buf, data.0, data.1)?;
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::SimpleString { data, attributes }
     }
     Resp3IndexFrame::SimpleError { data, attributes } => {
       let data = range_to_bytes(buf, data.0, data.1)?;
       let data = Str::from_inner(data)?;
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::SimpleError { data, attributes }
     }
     Resp3IndexFrame::BlobString { data, attributes } => {
       let data = range_to_bytes(buf, data.0, data.1)?;
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::BlobString { data, attributes }
     }
     Resp3IndexFrame::BlobError { data, attributes } => {
       let data = range_to_bytes(buf, data.0, data.1)?;
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::BlobError { data, attributes }
     }
     Resp3IndexFrame::Number { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::Number { data, attributes }
     }
     Resp3IndexFrame::Double { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::Double { data, attributes }
     }
     Resp3IndexFrame::Boolean { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::Boolean { data, attributes }
     }
     Resp3IndexFrame::Null => Resp3Frame::Null,
     Resp3IndexFrame::BigNumber { data, attributes } => {
       let data = range_to_bytes(buf, data.0, data.1)?;
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::BigNumber { data, attributes }
     }
     Resp3IndexFrame::VerbatimString {
@@ -58,7 +113,7 @@ fn make_bytes_frame(buf: &Bytes, frame: Resp3IndexFrame) -> Result<Resp3Frame, R
       format,
     } => {
       let data = range_to_bytes(buf, data.0, data.1)?;
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       Resp3Frame::VerbatimString {
         data,
         attributes,
@@ -71,36 +126,36 @@ fn make_bytes_frame(buf: &Bytes, frame: Resp3IndexFrame) -> Result<Resp3Frame, R
       Resp3Frame::ChunkedString(data)
     }
     Resp3IndexFrame::Array { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       let mut out = Vec::with_capacity(data.len());
       for frame in data.into_iter() {
-        out.push(make_bytes_frame(buf, frame)?);
+        out.push(build_bytes_frame(buf, frame)?);
       }
       Resp3Frame::Array { data: out, attributes }
     }
     Resp3IndexFrame::Push { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       let mut out = Vec::with_capacity(data.len());
       for frame in data.into_iter() {
-        out.push(make_bytes_frame(buf, frame)?);
+        out.push(build_bytes_frame(buf, frame)?);
       }
       Resp3Frame::Push { data: out, attributes }
     }
     Resp3IndexFrame::Map { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       let mut out = resp3_utils::new_map(Some(data.len()));
       for (key, value) in data.into_iter() {
-        let key = make_bytes_frame(buf, key)?;
-        let value = make_bytes_frame(buf, value)?;
+        let key = build_bytes_frame(buf, key)?;
+        let value = build_bytes_frame(buf, value)?;
         out.insert(key, value);
       }
       Resp3Frame::Map { data: out, attributes }
     }
     Resp3IndexFrame::Set { data, attributes } => {
-      let attributes = parse_as_attributes(buf, attributes)?;
+      let attributes = build_attributes(buf, attributes)?;
       let mut out = resp3_utils::new_set(Some(data.len()));
       for frame in data.into_iter() {
-        out.insert(make_bytes_frame(buf, frame)?);
+        out.insert(build_bytes_frame(buf, frame)?);
       }
       Resp3Frame::Set { data: out, attributes }
     }
@@ -122,7 +177,7 @@ fn freeze_parse(
   }
 
   let buffer = buf.split_to(amt).freeze();
-  let frame = make_bytes_frame(&buffer, frame)?;
+  let frame = build_bytes_frame(&buffer, frame)?;
   Ok((frame, amt, buffer))
 }
 

--- a/src/decode_mut/resp3.rs
+++ b/src/decode_mut/resp3.rs
@@ -1,0 +1,156 @@
+use crate::decode_mut::frame::Resp3IndexFrame;
+use crate::decode_mut::utils::range_to_bytes;
+use crate::resp3::types::{Attributes, Frame as Resp3Frame};
+use crate::resp3::utils as resp3_utils;
+use crate::types::{RedisProtocolError, RedisProtocolErrorKind};
+use bytes::{Bytes, BytesMut};
+use bytes_utils::Str;
+
+fn parse_as_attributes(buf: &Bytes, range: Option<(usize, usize)>) -> Result<Option<Attributes>, RedisProtocolError> {
+  unimplemented!()
+}
+// TODO reconsider storing attributes this way. they're already a map, so maybe make a FrameIndexMap and parse that...
+
+fn make_bytes_frame(buf: &Bytes, frame: Resp3IndexFrame) -> Result<Resp3Frame, RedisProtocolError> {
+  let out = match frame {
+    Resp3IndexFrame::SimpleString { data, attributes } => {
+      let data = range_to_bytes(buf, data.0, data.1)?;
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::SimpleString { data, attributes }
+    }
+    Resp3IndexFrame::SimpleError { data, attributes } => {
+      let data = range_to_bytes(buf, data.0, data.1)?;
+      let data = Str::from_inner(data)?;
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::SimpleError { data, attributes }
+    }
+    Resp3IndexFrame::BlobString { data, attributes } => {
+      let data = range_to_bytes(buf, data.0, data.1)?;
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::BlobString { data, attributes }
+    }
+    Resp3IndexFrame::BlobError { data, attributes } => {
+      let data = range_to_bytes(buf, data.0, data.1)?;
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::BlobError { data, attributes }
+    }
+    Resp3IndexFrame::Number { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::Number { data, attributes }
+    }
+    Resp3IndexFrame::Double { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::Double { data, attributes }
+    }
+    Resp3IndexFrame::Boolean { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::Boolean { data, attributes }
+    }
+    Resp3IndexFrame::Null => Resp3Frame::Null,
+    Resp3IndexFrame::BigNumber { data, attributes } => {
+      let data = range_to_bytes(buf, data.0, data.1)?;
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::BigNumber { data, attributes }
+    }
+    Resp3IndexFrame::VerbatimString {
+      data,
+      attributes,
+      format,
+    } => {
+      let data = range_to_bytes(buf, data.0, data.1)?;
+      let attributes = parse_as_attributes(buf, attributes)?;
+      Resp3Frame::VerbatimString {
+        data,
+        attributes,
+        format,
+      }
+    }
+    Resp3IndexFrame::Hello { version, auth } => Resp3Frame::Hello { version, auth },
+    Resp3IndexFrame::ChunkedString((start, end)) => {
+      let data = range_to_bytes(buf, start, end)?;
+      Resp3Frame::ChunkedString(data)
+    }
+    Resp3IndexFrame::Array { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      let mut out = Vec::with_capacity(data.len());
+      for frame in data.into_iter() {
+        out.push(make_bytes_frame(buf, frame)?);
+      }
+      Resp3Frame::Array { data: out, attributes }
+    }
+    Resp3IndexFrame::Push { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      let mut out = Vec::with_capacity(data.len());
+      for frame in data.into_iter() {
+        out.push(make_bytes_frame(buf, frame)?);
+      }
+      Resp3Frame::Push { data: out, attributes }
+    }
+    Resp3IndexFrame::Map { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      let mut out = resp3_utils::new_map(Some(data.len()));
+      for (key, value) in data.into_iter() {
+        let key = make_bytes_frame(buf, key)?;
+        let value = make_bytes_frame(buf, value)?;
+        out.insert(key, value);
+      }
+      Resp3Frame::Map { data: out, attributes }
+    }
+    Resp3IndexFrame::Set { data, attributes } => {
+      let attributes = parse_as_attributes(buf, attributes)?;
+      let mut out = resp3_utils::new_set(Some(data.len()));
+      for frame in data.into_iter() {
+        out.insert(make_bytes_frame(buf, frame)?);
+      }
+      Resp3Frame::Set { data: out, attributes }
+    }
+  };
+
+  Ok(out)
+}
+
+fn freeze_parse(
+  buf: &mut BytesMut,
+  frame: Resp3IndexFrame,
+  amt: usize,
+) -> Result<(Resp3Frame, usize, Bytes), RedisProtocolError> {
+  if amt > buf.len() {
+    return Err(RedisProtocolError::new(
+      RedisProtocolErrorKind::DecodeError,
+      "Invalid parsed amount > buffer length.",
+    ));
+  }
+
+  let buffer = buf.split_to(amt).freeze();
+  let frame = make_bytes_frame(&buffer, frame)?;
+  Ok((frame, amt, buffer))
+}
+
+pub mod complete {
+  use super::*;
+
+  /// Attempt to parse the contents of `buf`, returning the first valid frame, the number of bytes consumed, and the frozen consumed bytes.
+  ///
+  /// If the byte slice contains an incomplete frame then `None` is returned.
+  ///
+  /// Unlike `decode` this function works on a mutable `BytesMut` buffer in order to parse frames without copying the inner buffer contents
+  /// and will automatically split off the consumed bytes before returning. If an error or `None` is returned the buffer will not be modified.
+  pub fn decode_mut(buf: &mut BytesMut) -> Result<Option<(Resp3Frame, usize, Bytes)>, RedisProtocolError> {
+    unimplemented!()
+  }
+}
+
+pub mod streaming {
+  use super::*;
+  use crate::resp3::types::DecodedFrame;
+
+  /// Attempt to parse the contents of `buf`, returning the first valid frame, the number of bytes consumed, and the frozen consumed bytes.
+  ///
+  /// If the byte slice contains an incomplete frame then `None` is returned.
+  ///
+  /// Unlike `decode` this function works on a mutable `BytesMut` buffer in order to parse frames without copying the inner buffer contents
+  /// and will automatically split off the consumed bytes before returning. If an error or `None` is returned the buffer will not be modified.
+  pub fn decode_mut(buf: &mut BytesMut) -> Result<Option<(DecodedFrame, usize, Bytes)>, RedisProtocolError> {
+    unimplemented!()
+  }
+}

--- a/src/decode_mut/utils.rs
+++ b/src/decode_mut/utils.rs
@@ -1,0 +1,20 @@
+use crate::types::{RedisProtocolError, RedisProtocolErrorKind};
+use bytes::Bytes;
+use std::hash::{Hash, Hasher};
+
+pub fn hash_tuple<H: Hasher>(state: &mut H, range: &(usize, usize)) {
+  range.0.hash(state);
+  range.1.hash(state);
+}
+
+pub fn range_to_bytes(buf: &Bytes, start: usize, end: usize) -> Result<Bytes, RedisProtocolError> {
+  let len = buf.len();
+  if start > len || end > len {
+    return Err(RedisProtocolError::new(
+      RedisProtocolErrorKind::DecodeError,
+      "Invalid frame byte offset.",
+    ));
+  }
+
+  Ok(buf.slice(start..end))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,19 @@
+#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
+
 //! # Redis Protocol
 //!
 //! Structs and functions for implementing the [RESP2](https://redis.io/topics/protocol) and [RESP3](https://github.com/antirez/RESP3/blob/master/spec.md) protocol.
 //!
-//!
 //! ## Examples
 //!
-//! ```rust no_run ignore
+//! ```rust
 //! # extern crate redis_protocol;
 //! # extern crate bytes;
 //!
 //! use redis_protocol::resp2::prelude::*;
-//! use bytes::BytesMut;
+//! use bytes::{Bytes, BytesMut};
 //!
 //! fn main() {
 //!   let frame = Frame::BulkString("foobar".into());
@@ -22,7 +25,7 @@
 //!   };
 //!   println!("Encoded {} bytes into buffer with contents {:?}", len, buf);
 //!
-//!   let buf: BytesMut = "*3\r\n$3\r\nFoo\r\n$-1\r\n$3\r\nBar\r\n".into();
+//!   let buf: Bytes = "*3\r\n$3\r\nFoo\r\n$-1\r\n$3\r\nBar\r\n".into();
 //!   let (frame, consumed) = match decode(&buf) {
 //!     Ok(Some((f, c))) => (f, c),
 //!     Ok(None) => panic!("Incomplete frame."),
@@ -31,9 +34,11 @@
 //!   println!("Parsed frame {:?} and consumed {} bytes", frame, consumed);
 //!
 //!   let key = "foobarbaz";
-//!   println!("Hash slot for {}: {}", key, redis_keyslot(key));
+//!   println!("Hash slot for {}: {}", key, redis_keyslot(key.as_bytes()));
 //! }
 //! ```
+//!
+//! Note: if callers are not using the `index-map` feature then substitute `std::collections::HashMap` for any `IndexMap` types in these docs. `rustdoc` doesn't have a great way to show type substitutions based on feature flags.
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,10 @@ extern crate cookie_factory;
 #[macro_use]
 extern crate nom;
 
+#[cfg(test)]
+#[macro_use]
+extern crate pretty_env_logger;
+
 #[cfg(feature = "index-map")]
 extern crate indexmap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,8 @@
 extern crate log;
 #[macro_use]
 extern crate cookie_factory;
-#[macro_use]
-extern crate nom;
 
 #[cfg(test)]
-#[macro_use]
 extern crate pretty_env_logger;
 
 #[cfg(feature = "index-map")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@ extern crate indexmap;
 pub(crate) mod utils;
 pub(crate) mod nom_bytes;
 
+#[cfg(feature = "decode-mut")]
+mod decode_mut;
 /// Types and functions for implementing the RESP2 protocol.
 pub mod resp2;
 /// Types and functions for implementing the RESP3 protocol.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,4 +55,4 @@ pub mod resp3;
 /// Error types and general redis protocol types.
 pub mod types;
 
-pub use utils::{digits_in_number, redis_keyslot, resp2_frame_to_resp3, resp3_frame_to_resp2, ZEROED_KB};
+pub use utils::{digits_in_number, redis_keyslot, resp2_frame_to_resp3, ZEROED_KB};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ extern crate indexmap;
 
 #[macro_use]
 pub(crate) mod utils;
+pub(crate) mod nom_bytes;
 
 /// Types and functions for implementing the RESP2 protocol.
 pub mod resp2;

--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -1,0 +1,38 @@
+use bytes::BytesMut;
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct NomBytesMut {
+  inner: BytesMut,
+}
+
+impl From<BytesMut> for NomBytesMut {
+  fn from(d: BytesMut) -> Self {
+    NomBytesMut { inner: d }
+  }
+}
+
+impl Deref for NomBytesMut {
+  type Target = BytesMut;
+
+  fn deref(&self) -> &Self::Target {
+    &self.inner
+  }
+}
+
+impl DerefMut for NomBytesMut {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.inner
+  }
+}
+
+impl nom::InputTake for NomBytesMut {
+  fn take(&self, count: usize) -> Self {
+    // operate on a shallow copy and split off the bytes to create a new shallow window into the bytes
+    self.clone().split_to(count).into()
+  }
+  fn take_split(&self, count: usize) -> (Self, Self) {
+    let mut right = self.clone();
+    let left = right.split_to(count);
+    (left.into(), right)
+  }
+}

--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -1,5 +1,7 @@
+use crate::types::RedisParseError;
 use bytes::buf::{Chain, IntoIter, Reader, Take};
 use bytes::{Buf, Bytes, BytesMut};
+use bytes_utils::Str;
 use nom::{
   AsBytes, FindSubstring, InputIter, InputLength, InputTake, InputTakeAtPosition, Needed, Offset, Slice,
   UnspecializedInput,
@@ -42,6 +44,10 @@ pub struct NomBytes(Bytes);
 impl NomBytes {
   pub fn into_bytes(self) -> Bytes {
     self.0
+  }
+
+  pub fn as_str<T>(&self) -> Result<Str, RedisParseError<T>> {
+    Ok(Str::from_inner(self.0.clone())?)
   }
 }
 

--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -1,12 +1,9 @@
 use bytes::buf::IntoIter;
 use bytes::BytesMut;
-use nom::bitvec::view::AsBits;
-use nom::error::{ErrorKind, ParseError};
-use nom::{AsBytes, CompareResult, IResult, InputLength, Needed};
-use std::iter::{Copied, Enumerate, Map};
-use std::marker::PhantomData;
+use nom::{AsBytes, Needed};
+use std::iter::Enumerate;
 use std::ops::{Deref, DerefMut, Range, RangeFrom, RangeFull, RangeTo};
-use std::slice::Iter;
+#[cfg(feature = "decode-logs")]
 use std::str;
 
 /// A wrapper type for `BytesMut` that implements the Nom traits necessary to operate on BytesMut slices directly with nom functions.

--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -4,14 +4,12 @@ use nom::{
   AsBytes, FindSubstring, InputIter, InputLength, InputTake, InputTakeAtPosition, Needed, Offset, Slice,
   UnspecializedInput,
 };
+use std::fmt::{Debug, Display};
 use std::io::IoSlice;
 use std::iter::Enumerate;
 use std::ops::{Deref, DerefMut, Range, RangeFrom, RangeFull, RangeTo};
 #[cfg(feature = "decode-logs")]
 use std::str;
-
-// TODO
-// need to make  this work so it works for byte slices, vec<u8>, and Bytes
 
 /// A wrapper type for `BytesMut` that implements the Nom traits necessary to operate on BytesMut slices directly with nom functions.
 ///
@@ -40,45 +38,6 @@ use std::str;
 /// `Clone` impl on `BytesMut` allows for removing any lifetimes and the issues that come with using those for this kind of use case.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NomBytes(Bytes);
-
-/// Helper trait for generic parser functions that operate on anything that can be used with nom, including `&[u8]` and `NomBytes`.
-///
-/// This trait also requires that the implementing type implement `AsRef<Self>` so it can work effectively with nom functions.
-pub trait CanParse<'a>:
-  InputIter
-  + InputTake
-  + AsRef<Self>
-  + UnspecializedInput
-  + InputLength
-  + InputTakeAtPosition
-  + FindSubstring<&'a [u8]>
-  + Offset
-  + Slice<Range<usize>>
-  + Slice<RangeTo<usize>>
-  + Slice<RangeFrom<usize>>
-  + Slice<RangeFull>
-where
-  Self: Sized,
-{
-}
-
-impl<'a, T> CanParse<'a> for T
-where
-  Self: Sized,
-  T: InputIter
-    + InputTake
-    + AsRef<Self>
-    + UnspecializedInput
-    + InputLength
-    + InputTakeAtPosition
-    + FindSubstring<&'a [u8]>
-    + Offset
-    + Slice<Range<usize>>
-    + Slice<RangeTo<usize>>
-    + Slice<RangeFrom<usize>>
-    + Slice<RangeFull>,
-{
-}
 
 impl NomBytes {
   pub fn into_bytes(self) -> Bytes {
@@ -179,7 +138,7 @@ impl InputIter for NomBytes {
 
 impl Offset for NomBytes {
   fn offset(&self, second: &Self) -> usize {
-    self.0.as_bytes().offset(second.inner.as_bytes())
+    self.0.as_bytes().offset(second.0.as_bytes())
   }
 }
 

--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -1,13 +1,27 @@
+use bytes::buf::IntoIter;
 use bytes::BytesMut;
+use nom::bitvec::view::AsBits;
+use nom::error::{ErrorKind, ParseError};
+use nom::{AsBytes, CompareResult, IResult, InputLength, Needed};
+use std::iter::{Copied, Enumerate, Map};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut, Range, RangeFrom, RangeFull, RangeTo};
+use std::slice::Iter;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub(crate) struct NomBytesMut {
   inner: BytesMut,
 }
 
+impl NomBytesMut {
+  pub fn into_bytes(self) -> BytesMut {
+    self.inner
+  }
+}
+
 impl From<BytesMut> for NomBytesMut {
-  fn from(d: BytesMut) -> Self {
-    NomBytesMut { inner: d }
+  fn from(buf: BytesMut) -> Self {
+    NomBytesMut { inner: buf }
   }
 }
 
@@ -25,6 +39,12 @@ impl DerefMut for NomBytesMut {
   }
 }
 
+impl AsRef<NomBytesMut> for NomBytesMut {
+  fn as_ref(&self) -> &NomBytesMut {
+    &self
+  }
+}
+
 impl nom::InputTake for NomBytesMut {
   fn take(&self, count: usize) -> Self {
     // operate on a shallow copy and split off the bytes to create a new shallow window into the bytes
@@ -34,5 +54,79 @@ impl nom::InputTake for NomBytesMut {
     let mut right = self.clone();
     let left = right.split_to(count);
     (left.into(), right)
+  }
+}
+
+impl nom::InputLength for NomBytesMut {
+  fn input_len(&self) -> usize {
+    self.inner.len()
+  }
+}
+
+impl<'a> nom::FindSubstring<&'a [u8]> for NomBytesMut {
+  fn find_substring(&self, substr: &'a [u8]) -> Option<usize> {
+    self.inner.as_bytes().find_substring(substr)
+  }
+}
+
+impl nom::UnspecializedInput for NomBytesMut {}
+
+impl nom::InputIter for NomBytesMut {
+  type Item = u8;
+  type Iter = Enumerate<Self::IterElem>;
+  type IterElem = IntoIter<BytesMut>;
+
+  fn iter_indices(&self) -> Self::Iter {
+    self.iter_elements().enumerate()
+  }
+
+  fn iter_elements(&self) -> Self::IterElem {
+    self.inner.clone().into_iter()
+  }
+
+  fn position<P>(&self, predicate: P) -> Option<usize>
+  where
+    P: Fn(Self::Item) -> bool,
+  {
+    self.inner.as_bytes().position(predicate)
+  }
+
+  fn slice_index(&self, count: usize) -> Result<usize, Needed> {
+    self.inner.as_bytes().slice_index(count)
+  }
+}
+
+impl nom::Offset for NomBytesMut {
+  fn offset(&self, second: &Self) -> usize {
+    self.inner.as_bytes().offset(second.inner.as_bytes())
+  }
+}
+
+impl nom::Slice<Range<usize>> for NomBytesMut {
+  fn slice(&self, range: Range<usize>) -> Self {
+    let mut buf = self.clone();
+    let _ = buf.split_to(range.start);
+    buf.split_to(range.end + 1).into()
+  }
+}
+
+impl nom::Slice<RangeTo<usize>> for NomBytesMut {
+  fn slice(&self, range: RangeTo<usize>) -> Self {
+    let mut buf = self.clone();
+    buf.split_to(range.end + 1).into()
+  }
+}
+
+impl nom::Slice<RangeFrom<usize>> for NomBytesMut {
+  fn slice(&self, range: RangeFrom<usize>) -> Self {
+    let mut buf = self.clone();
+    let _ = buf.split_to(range.start);
+    buf
+  }
+}
+
+impl nom::Slice<RangeFull> for NomBytesMut {
+  fn slice(&self, _: RangeFull) -> Self {
+    self.clone()
   }
 }

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -20,7 +20,7 @@ fn to_i64(s: &str) -> Result<i64, ParseIntError> {
 }
 
 fn map_error(s: &str) -> Frame {
-  Frame::Error(s.to_owned())
+  Frame::Error(s.into())
 }
 
 fn isize_to_usize<'a>(s: isize) -> Result<usize, RedisProtocolError> {
@@ -53,7 +53,7 @@ named!(
 
 named!(
   parse_simplestring<Frame>,
-  do_parse!(data: read_to_crlf_s >> (Frame::SimpleString(data.to_owned())))
+  do_parse!(data: read_to_crlf_s >> (Frame::SimpleString(data.into())))
 );
 
 named!(
@@ -70,7 +70,7 @@ named!(parse_error<Frame>, map!(read_to_crlf_s, map_error));
 named_args!(parse_bulkstring(len: isize) <Frame>,
   do_parse!(
     d: terminated!(take!(len), take!(2)) >>
-    (Frame::BulkString(Vec::from(d)))
+    (Frame::BulkString(d.into()))
   )
 );
 

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -161,10 +161,7 @@ where
 /// If the byte slice contains an incomplete frame then `None` is returned.
 pub fn decode(buf: &Bytes) -> Result<Option<(Frame, usize)>, RedisProtocolError> {
   let len = buf.len();
-  // operate on a shallow clone with a different cursor than `buf` since the parser will split the buffer while parsing
-  // in order to avoid allocating as much as possible, and if a frame is later found to be incomplete we won't affect
-  // the caller's buffer cursor
-  let buffer: NomBytes = buf.clone().into();
+  let buffer: NomBytes = buf.into();
 
   match d_parse_frame(buffer) {
     Ok((remaining, frame)) => Ok(Some((frame, len - remaining.len()))),

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -185,11 +185,6 @@ pub mod tests {
   use nom::AsBytes;
   use std::str;
 
-  #[test]
-  fn enable_logs() {
-    pretty_env_logger::try_init();
-  }
-
   pub const PADDING: &'static str = "FOOBARBAZ";
 
   pub fn pretty_print_panic(e: RedisProtocolError) {

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -17,13 +17,15 @@ use std::str;
 
 const NULL_LEN: isize = -1;
 
-fn to_isize(s: &str) -> Result<isize, RedisParseError<NomBytes>> {
-  s.parse::<isize>()
+fn to_isize(s: &NomBytes) -> Result<isize, RedisParseError<NomBytes>> {
+  str::from_utf8(s)?
+    .parse::<isize>()
     .map_err(|_| RedisParseError::new_custom("to_isize", "Failed to parse as integer."))
 }
 
-fn to_i64(s: &str) -> Result<i64, RedisParseError<NomBytes>> {
-  s.parse::<i64>()
+fn to_i64(s: &NomBytes) -> Result<i64, RedisParseError<NomBytes>> {
+  str::from_utf8(s)?
+    .parse::<i64>()
     .map_err(|_| RedisParseError::new_custom("to_i64", "Failed to parse as integer."))
 }
 

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -4,6 +4,7 @@
 
 use crate::resp2::types::*;
 use crate::types::*;
+use crate::utils;
 use bytes::{Bytes, BytesMut};
 use bytes_utils::{Str, StrMut};
 use log::Level::Trace;
@@ -38,11 +39,6 @@ fn isize_to_usize<'a>(s: isize) -> Result<usize, RedisParseError<NomBytesMut>> {
   }
 }
 
-fn to_strmut(data: &NomBytesMut) -> Result<StrMut, RedisParseError<NomBytesMut>> {
-  StrMut::from_inner(data.clone().into_bytes())
-    .map_err(|error| RedisParseError::Nom(data.clone(), NomErrorKind::ParseTo))
-}
-
 fn d_read_to_crlf(input: &NomBytesMut) -> IResult<NomBytesMut, NomBytesMut, RedisParseError<NomBytesMut>> {
   decode_log!(input, "Parsing to CRLF. Remaining: {:?}", input);
   nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.clone())
@@ -51,7 +47,7 @@ fn d_read_to_crlf(input: &NomBytesMut) -> IResult<NomBytesMut, NomBytesMut, Redi
 fn d_read_to_crlf_s(input: &NomBytesMut) -> IResult<NomBytesMut, StrMut, RedisParseError<NomBytesMut>> {
   let (input, data) = d_read_to_crlf(input)?;
   decode_log!(data, "Parsing to StrMut. Data: {:?}", data);
-  Ok((input, etry!(to_strmut(&data))))
+  Ok((input, etry!(utils::to_strmut(&data))))
 }
 
 fn d_read_prefix_len(input: &NomBytesMut) -> IResult<NomBytesMut, isize, RedisParseError<NomBytesMut>> {

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -2,22 +2,18 @@
 //!
 //! <https://redis.io/topics/protocol#resp-protocol-description>
 
+use crate::nom_bytes::NomBytesMut;
 use crate::resp2::types::*;
 use crate::types::*;
 use crate::utils;
-use bytes::{Bytes, BytesMut};
-use bytes_utils::{Str, StrMut};
-use log::Level::Trace;
+use bytes::BytesMut;
+use bytes_utils::StrMut;
 use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
-use nom::combinator::{map as nom_map, map_res as nom_map_res, opt as nom_opt};
-use nom::error::ErrorKind as NomErrorKind;
 use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
 use nom::{Err as NomErr, IResult};
-use std::num::ParseIntError;
 use std::str;
-use std::str::Utf8Error;
 
 const NULL_LEN: isize = -1;
 
@@ -324,8 +320,6 @@ mod tests {
 
   #[test]
   fn should_decode_moved_error() {
-    pretty_env_logger::try_init();
-
     let mut bytes: BytesMut = "-MOVED 3999 127.0.0.1:6381\r\n".into();
     let expected = (Some(Frame::Error("MOVED 3999 127.0.0.1:6381".into())), bytes.len());
 

--- a/src/resp2/encode.rs
+++ b/src/resp2/encode.rs
@@ -9,12 +9,12 @@ use crate::utils;
 use bytes::BytesMut;
 use cookie_factory::GenError;
 
-fn gen_simplestring<'a>(x: (&'a mut [u8], usize), data: &str) -> Result<(&'a mut [u8], usize), GenError> {
+fn gen_simplestring<'a>(x: (&'a mut [u8], usize), data: &[u8]) -> Result<(&'a mut [u8], usize), GenError> {
   encode_checks!(x, resp2_utils::simplestring_encode_len(data));
 
   do_gen!(
     x,
-    gen_be_u8!(FrameKind::SimpleString.to_byte()) >> gen_slice!(data.as_bytes()) >> gen_slice!(CRLF.as_bytes())
+    gen_be_u8!(FrameKind::SimpleString.to_byte()) >> gen_slice!(data) >> gen_slice!(CRLF.as_bytes())
   )
 }
 

--- a/src/resp2/types.rs
+++ b/src/resp2/types.rs
@@ -2,7 +2,7 @@ use crate::resp2::utils as resp2_utils;
 use crate::types::{Redirection, RedisProtocolError};
 use crate::utils;
 use bytes::BytesMut;
-use bytes_utils::Str;
+use bytes_utils::{Str, StrMut};
 use std::mem;
 use std::str;
 
@@ -64,9 +64,9 @@ impl FrameKind {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Frame {
   /// A short non binary-safe string.
-  SimpleString(Str),
+  SimpleString(StrMut),
   /// A short non binary-safe string representing an error.
-  Error(Str),
+  Error(StrMut),
   /// A signed 64 bit integer.
   Integer(i64),
   /// A binary-safe string.

--- a/src/resp2/types.rs
+++ b/src/resp2/types.rs
@@ -2,7 +2,7 @@ use crate::resp2::utils as resp2_utils;
 use crate::types::{Redirection, RedisProtocolError};
 use crate::utils;
 use bytes::BytesMut;
-use bytes_utils::{Str, StrMut};
+use bytes_utils::StrMut;
 use std::mem;
 use std::str;
 

--- a/src/resp2/types.rs
+++ b/src/resp2/types.rs
@@ -183,8 +183,7 @@ impl Frame {
   // Copy and read the inner value as a string, if possible.
   pub fn to_string(&self) -> Option<String> {
     match *self {
-      Frame::SimpleString(ref s) => Some(s.to_string()),
-      Frame::BulkString(ref b) => String::from_utf8(b.to_vec()).ok(),
+      Frame::BulkString(ref b) | Frame::SimpleString(ref b) => String::from_utf8(b.to_vec()).ok(),
       _ => None,
     }
   }

--- a/src/resp2/utils.rs
+++ b/src/resp2/utils.rs
@@ -14,12 +14,12 @@ pub fn array_encode_len(frames: &Vec<Frame>) -> Result<usize, GenError> {
     .fold(Ok(padding), |m, f| m.and_then(|s| encode_len(f).map(|l| s + l)))
 }
 
-pub fn simplestring_encode_len(s: &str) -> usize {
+pub fn simplestring_encode_len(s: &[u8]) -> usize {
   1 + s.len() + 2
 }
 
 pub fn error_encode_len(s: &str) -> usize {
-  1 + s.len() + 2
+  1 + s.as_bytes().len() + 2
 }
 
 pub fn integer_encode_len(i: &i64) -> usize {
@@ -67,9 +67,9 @@ mod tests {
     let ss2 = "FooBarBaz";
     let ss3 = "-&#$@9232";
 
-    assert_eq!(simplestring_encode_len(ss1), 5);
-    assert_eq!(simplestring_encode_len(ss2), 12);
-    assert_eq!(simplestring_encode_len(ss3), 12);
+    assert_eq!(simplestring_encode_len(ss1.as_bytes()), 5);
+    assert_eq!(simplestring_encode_len(ss2.as_bytes()), 12);
+    assert_eq!(simplestring_encode_len(ss3.as_bytes()), 12);
   }
 
   #[test]

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -141,8 +141,9 @@ fn d_read_to_crlf<T>(input: T) -> IResult<NomBytesMut, NomBytesMut, RedisParseEr
 where
   T: AsRef<NomBytesMut> + Debug,
 {
-  decode_log!(input, "Parsing to CRLF. Remaining: {:?}", input);
-  nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.as_ref().clone())
+  let input_ref = input.as_ref();
+  decode_log!(input_ref, "Parsing to CRLF. Remaining: {:?}", input_ref);
+  nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input_ref.clone())
 }
 
 fn d_read_to_crlf_s<T>(input: T) -> IResult<NomBytesMut, StrMut, RedisParseError<NomBytesMut>>

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -2,14 +2,14 @@
 //!
 //! <https://github.com/antirez/RESP3/blob/master/spec.md>
 
+use crate::nom_bytes::NomBytesMut;
 use crate::resp3::types::*;
 use crate::resp3::utils as resp3_utils;
 use crate::types::*;
 use crate::utils;
-use bytes_utils::{Str, StrMut};
+use bytes_utils::StrMut;
 use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
 use nom::combinator::{map as nom_map, map_res as nom_map_res, opt as nom_opt};
-use nom::error::ErrorKind as NomErrorKind;
 use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
@@ -17,7 +17,6 @@ use nom::{Err as NomErr, IResult};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::Deref;
-use std::str;
 
 fn map_complete_frame(frame: Frame) -> DecodedFrame {
   DecodedFrame::Complete(frame)

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -14,21 +14,6 @@ use nom::{Err as NomErr, IResult};
 use std::borrow::Cow;
 use std::str;
 
-macro_rules! e (
-  ($err:expr) => {
-    return Err($err.into_nom_error())
-  }
-);
-
-macro_rules! etry (
-  ($expr:expr) => {
-    match $expr {
-      Ok(result) => result,
-      Err(e) => return Err(e.into_nom_error())
-    }
-  }
-);
-
 fn map_complete_frame(frame: Frame) -> DecodedFrame {
   DecodedFrame::Complete(frame)
 }

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -14,8 +14,6 @@ use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
 use nom::{Err as NomErr, IResult};
-use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str;
 
@@ -85,7 +83,6 @@ pub(crate) fn to_verbatimstring_format<T>(s: &[u8]) -> Result<VerbatimStringForm
   }
 }
 
-// TODO change auth fields to Str
 pub(crate) fn to_hello<T>(version: u8, auth: Option<(Str, Str)>) -> Result<Frame, RedisParseError<T>> {
   let version = match version {
     2 => RespVersion::RESP2,
@@ -95,10 +92,7 @@ pub(crate) fn to_hello<T>(version: u8, auth: Option<(Str, Str)>) -> Result<Frame
     }
   };
   let auth = if let Some((username, password)) = auth {
-    Some(Auth {
-      username: Cow::Owned(username.to_string()),
-      password: Cow::Owned(password.to_string()),
-    })
+    Some(Auth { username, password })
   } else {
     None
   };

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -179,7 +179,7 @@ fn d_parse_simplestring(input: &[u8]) -> IResult<&[u8], Frame, RedisParseError<&
   Ok((
     input,
     Frame::SimpleString {
-      data: data.to_owned(),
+      data: data.into(),
       attributes: None,
     },
   ))
@@ -191,7 +191,7 @@ fn d_parse_simpleerror(input: &[u8]) -> IResult<&[u8], Frame, RedisParseError<&[
   Ok((
     input,
     Frame::SimpleError {
-      data: data.to_owned(),
+      data: data.into(),
       attributes: None,
     },
   ))
@@ -226,7 +226,7 @@ fn d_parse_blobstring(input: &[u8], len: usize) -> IResult<&[u8], Frame, RedisPa
   Ok((
     input,
     Frame::BlobString {
-      data: data.to_vec(),
+      data: data.into(),
       attributes: None,
     },
   ))
@@ -239,7 +239,7 @@ fn d_parse_bloberror(input: &[u8]) -> IResult<&[u8], Frame, RedisParseError<&[u8
   Ok((
     input,
     Frame::BlobError {
-      data: data.to_vec(),
+      data: data.into(),
       attributes: None,
     },
   ))
@@ -254,7 +254,7 @@ fn d_parse_verbatimstring(input: &[u8]) -> IResult<&[u8], Frame, RedisParseError
   Ok((
     input,
     Frame::VerbatimString {
-      data: data.to_vec(),
+      data: data.into(),
       format,
       attributes: None,
     },
@@ -267,7 +267,7 @@ fn d_parse_bignumber(input: &[u8]) -> IResult<&[u8], Frame, RedisParseError<&[u8
   Ok((
     input,
     Frame::BigNumber {
-      data: data.to_vec(),
+      data: data.into(),
       attributes: None,
     },
   ))
@@ -385,7 +385,7 @@ fn d_parse_chunked_string(input: &[u8]) -> IResult<&[u8], DecodedFrame, RedisPar
     (input, Frame::new_end_stream())
   } else {
     let (input, contents) = nom_terminated(nom_take(len), nom_take(2_usize))(input)?;
-    (input, Frame::ChunkedString(Vec::from(contents)))
+    (input, Frame::ChunkedString(contents.into()))
   };
 
   Ok((input, DecodedFrame::Complete(frame)))
@@ -1044,7 +1044,7 @@ mod tests {
   fn should_decode_bignumber() {
     let expected = (
       Some(Frame::BigNumber {
-        data: "3492890328409238509324850943850943825024385".as_bytes().to_vec(),
+        data: "3492890328409238509324850943850943825024385".into(),
         attributes: None,
       }),
       46,
@@ -1068,7 +1068,7 @@ mod tests {
   fn should_decode_verbatim_string_mkd() {
     let expected = (
       Some(Frame::VerbatimString {
-        data: "Some string".as_bytes().to_vec(),
+        data: "Some string".into(),
         format: VerbatimStringFormat::Markdown,
         attributes: None,
       }),
@@ -1084,7 +1084,7 @@ mod tests {
   fn should_decode_verbatim_string_txt() {
     let expected = (
       Some(Frame::VerbatimString {
-        data: "Some string".as_bytes().to_vec(),
+        data: "Some string".into(),
         format: VerbatimStringFormat::Text,
         attributes: None,
       }),

--- a/src/resp3/encode.rs
+++ b/src/resp3/encode.rs
@@ -19,14 +19,14 @@ macro_rules! encode_attributes (
 
 fn gen_simplestring<'a>(
   mut x: (&'a mut [u8], usize),
-  data: &str,
+  data: &[u8],
   attributes: &Option<Attributes>,
 ) -> Result<(&'a mut [u8], usize), GenError> {
   encode_attributes!(x, attributes);
 
   do_gen!(
     x,
-    gen_be_u8!(FrameKind::SimpleString.to_byte()) >> gen_slice!(data.as_bytes()) >> gen_slice!(CRLF.as_bytes())
+    gen_be_u8!(FrameKind::SimpleString.to_byte()) >> gen_slice!(data) >> gen_slice!(CRLF.as_bytes())
   )
 }
 

--- a/src/resp3/encode.rs
+++ b/src/resp3/encode.rs
@@ -380,7 +380,7 @@ fn attempt_encoding<'a>(buf: &'a mut [u8], offset: usize, frame: &Frame) -> Resu
 ///
 /// async fn example(socket: &mut TcpStream, buf: &mut BytesMut) -> Result<(), RedisProtocolError> {
 ///   // in many cases the starting buffer wont be empty, so this example shows how to track the offset as well
-///   let frame = (FrameKind::BlobString, "foobarbaz").try_into()?;
+///   let frame = Frame::BlobString { data: "foobarbaz".into(), attributes: None };
 ///   let offset = encode_bytes(buf, &frame).expect("Failed to encode frame");
 ///   
 ///   let _ = socket.write_all(&buf).await.expect("Failed to write to socket");
@@ -1223,7 +1223,7 @@ mod tests {
     let expected = "=15\r\ntxt:Some string\r\n";
     let input = Frame::VerbatimString {
       format: VerbatimStringFormat::Text,
-      data: "Some string".as_bytes().to_vec(),
+      data: "Some string".as_bytes().into(),
       attributes: None,
     };
 
@@ -1238,7 +1238,7 @@ mod tests {
     let expected = "=15\r\nmkd:Some string\r\n";
     let input = Frame::VerbatimString {
       format: VerbatimStringFormat::Markdown,
-      data: "Some string".as_bytes().to_vec(),
+      data: "Some string".as_bytes().into(),
       attributes: None,
     };
 
@@ -1454,7 +1454,7 @@ mod tests {
       attributes: None,
     };
     let chunk4 = Frame::BlobString {
-      data: "foobarbaz".as_bytes().to_vec(),
+      data: "foobarbaz".as_bytes().into(),
       attributes: None,
     };
 
@@ -1503,7 +1503,7 @@ mod tests {
       attributes: None,
     };
     let chunk4 = Frame::BlobString {
-      data: "foobarbaz".as_bytes().to_vec(),
+      data: "foobarbaz".as_bytes().into(),
       attributes: None,
     };
 

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -1,8 +1,8 @@
 use crate::resp3::utils as resp3_utils;
 use crate::types::{Redirection, RedisProtocolError, RedisProtocolErrorKind};
 use crate::utils;
-use bytes::{Bytes, BytesMut};
-use bytes_utils::{Str, StrMut};
+use bytes::Bytes;
+use bytes_utils::Str;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
@@ -13,8 +13,6 @@ use std::str;
 #[cfg(feature = "index-map")]
 use indexmap::{IndexMap, IndexSet};
 
-#[cfg(test)]
-use nom::AsBytes;
 #[cfg(test)]
 use std::convert::TryInto;
 
@@ -405,8 +403,8 @@ impl PartialEq for Frame {
         match *other {
           Array {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -418,8 +416,8 @@ impl PartialEq for Frame {
         match *other {
           BlobString {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -431,8 +429,8 @@ impl PartialEq for Frame {
         match *other {
           SimpleString {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -444,8 +442,8 @@ impl PartialEq for Frame {
         match *other {
           SimpleError {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -457,8 +455,8 @@ impl PartialEq for Frame {
         match *other {
           Number {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -474,8 +472,8 @@ impl PartialEq for Frame {
         match *other {
           Boolean {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -487,8 +485,8 @@ impl PartialEq for Frame {
         match *other {
           Double {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -500,8 +498,8 @@ impl PartialEq for Frame {
         match *other {
           BlobError {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -528,8 +526,8 @@ impl PartialEq for Frame {
         match *other {
           Map {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -541,8 +539,8 @@ impl PartialEq for Frame {
         match *other {
           Set {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -554,8 +552,8 @@ impl PartialEq for Frame {
         match *other {
           Push {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }
@@ -574,8 +572,8 @@ impl PartialEq for Frame {
         match *other {
           BigNumber {
             ref data,
-            attributes: _,
-          } => data == _data && _attributes == _attributes,
+            ref attributes,
+          } => data == _data && attributes == _attributes,
           _ => false,
         }
       }

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -301,6 +301,8 @@ pub enum Frame {
     attributes: Option<Attributes>,
   },
   /// A small non binary-safe string.
+  ///
+  /// The internal data type is `Bytes` in order to support callers that use this interface to parse a `MONITOR` stream.
   SimpleString {
     data: Bytes,
     attributes: Option<Attributes>,

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -2,17 +2,21 @@ use crate::resp3::utils as resp3_utils;
 use crate::types::{Redirection, RedisProtocolError, RedisProtocolErrorKind};
 use crate::utils;
 use bytes::BytesMut;
-use bytes_utils::{Str, StrMut};
+use bytes_utils::StrMut;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::str;
 
 #[cfg(feature = "index-map")]
 use indexmap::{IndexMap, IndexSet};
+
+#[cfg(test)]
 use nom::AsBytes;
+#[cfg(test)]
+use std::convert::TryInto;
 
 /// Byte prefix before a simple string type.
 pub const SIMPLE_STRING_BYTE: u8 = b'+';

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -99,13 +99,6 @@ pub type FrameSet = IndexSet<Frame>;
 /// Additional information returned alongside a frame.
 pub type Attributes = FrameMap;
 
-/// Enum describing the byte ordering for numbers and doubles when cast to byte slices.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ByteOrder {
-  BigEndian,
-  LittleEndian,
-}
-
 /// The RESP version used in the `HELLO` request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RespVersion {
@@ -1112,21 +1105,6 @@ impl Frame {
       }
       Frame::VerbatimString { ref data, .. } => Some(data),
       Frame::ChunkedString(ref b) => Some(b),
-      _ => None,
-    }
-  }
-
-  /// Attempt the read the frame as bytes if the inner type is an `i64` or `f64`.
-  pub fn number_or_double_as_bytes(&self, ordering: ByteOrder) -> Option<[u8; 8]> {
-    match *self {
-      Frame::Double { ref data, .. } => Some(match ordering {
-        ByteOrder::BigEndian => data.to_be_bytes(),
-        ByteOrder::LittleEndian => data.to_le_bytes(),
-      }),
-      Frame::Number { ref data, .. } => Some(match ordering {
-        ByteOrder::BigEndian => data.to_be_bytes(),
-        ByteOrder::LittleEndian => data.to_le_bytes(),
-      }),
       _ => None,
     }
   }

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -3,7 +3,6 @@ use crate::types::{Redirection, RedisProtocolError, RedisProtocolErrorKind};
 use crate::utils;
 use bytes::Bytes;
 use bytes_utils::Str;
-use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
@@ -116,16 +115,16 @@ impl RespVersion {
 /// Authentication information used in the `HELLO` request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Auth {
-  pub username: Cow<'static, str>,
-  pub password: Cow<'static, str>,
+  pub username: Str,
+  pub password: Str,
 }
 
 impl Auth {
   /// Create an [Auth] struct using the "default" user with the provided password.
-  pub fn from_password<S: Into<String>>(password: S) -> Auth {
+  pub fn from_password<S: Into<Str>>(password: S) -> Auth {
     Auth {
-      username: Cow::Borrowed("default"),
-      password: Cow::Owned(password.into()),
+      username: Str::from("default"),
+      password: password.into(),
     }
   }
 }
@@ -147,7 +146,7 @@ impl VerbatimStringFormat {
 
   pub(crate) fn encode_len(&self) -> usize {
     match *self {
-      // the colon suffix is included here
+      // the trailing colon is included here
       VerbatimStringFormat::Text => 4,
       VerbatimStringFormat::Markdown => 4,
     }

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -2,7 +2,7 @@ use crate::resp3::utils as resp3_utils;
 use crate::types::{Redirection, RedisProtocolError, RedisProtocolErrorKind};
 use crate::utils;
 use bytes::BytesMut;
-use bytes_utils::Str;
+use bytes_utils::{Str, StrMut};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
@@ -304,9 +304,15 @@ pub enum Frame {
     attributes: Option<Attributes>,
   },
   /// A small non binary-safe string.
-  SimpleString { data: Str, attributes: Option<Attributes> },
+  SimpleString {
+    data: StrMut,
+    attributes: Option<Attributes>,
+  },
   /// A small non binary-safe string representing an error.
-  SimpleError { data: Str, attributes: Option<Attributes> },
+  SimpleError {
+    data: StrMut,
+    attributes: Option<Attributes>,
+  },
   /// A boolean type.
   Boolean { data: bool, attributes: Option<Attributes> },
   /// A null type.

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -1220,26 +1220,27 @@ impl Frame {
 /// A helper struct for reading and managing streaming data types.
 ///
 /// ```rust edition2018
+/// # use bytes::BytesMut;
 /// use redis_protocol::resp3::decode::streaming::decode;
 ///
 /// fn main() {
-///   let parts = vec!["*?\r\n", ":1\r\n", ":2\r\n:3\r\n", ".\r\n"];
+///   let parts: Vec<BytesMut> = vec!["*?\r\n".into(), ":1\r\n".into(), ":2\r\n".into(), ".\r\n".into()];
 ///
-///   let (frame, _) = decode(parts[0].as_bytes()).unwrap().unwrap();
+///   let (frame, _) = decode(&parts[0]).unwrap().unwrap();
 ///   assert!(frame.is_streaming());
 ///   let mut streaming = frame.into_streaming_frame().unwrap();
 ///   println!("Reading streaming {:?}", streaming.kind);
 ///
-///   let (frame, _) = decode(parts[1].as_bytes()).unwrap().unwrap();
+///   let (frame, _) = decode(&parts[1]).unwrap().unwrap();
 ///   assert!(frame.is_complete());
 ///   // add frames to the buffer until we reach the terminating byte sequence
 ///   streaming.add_frame(frame.into_complete_frame().unwrap());
 ///
-///   let (frame, _) = decode(parts[2].as_bytes()).unwrap().unwrap();
+///   let (frame, _) = decode(&parts[2]).unwrap().unwrap();
 ///   assert!(frame.is_complete());
 ///   streaming.add_frame(frame.into_complete_frame().unwrap());
 ///
-///   let (frame, _) = decode(parts[3].as_bytes()).unwrap().unwrap();
+///   let (frame, _) = decode(&parts[3]).unwrap().unwrap();
 ///   assert!(frame.is_complete());
 ///   streaming.add_frame(frame.into_complete_frame().unwrap());
 ///
@@ -1247,7 +1248,7 @@ impl Frame {
 ///   // convert the buffer into one frame
 ///   let result = streaming.into_frame().unwrap();
 ///
-///   // Frame::Array { data: [1, 2, 3], attributes: None }
+///   // Frame::Array { data: [1, 2], attributes: None }
 ///   println!("{:?}", result);
 /// }
 /// ```

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -1094,8 +1094,6 @@ impl Frame {
   }
 
   /// Attempt to read the frame as a byte slice.
-  ///
-  /// Number and Double will not be returned as a byte slice. Use [number_or_double_as_bytes](Self::number_or_double_as_bytes) instead.
   pub fn as_bytes(&self) -> Option<&[u8]> {
     match *self {
       Frame::SimpleError { ref data, .. } => Some(data.as_bytes()),

--- a/src/resp3/utils.rs
+++ b/src/resp3/utils.rs
@@ -94,8 +94,8 @@ pub fn bignumber_encode_len(b: &[u8]) -> usize {
   1 + b.len() + 2
 }
 
-pub fn simplestring_encode_len(s: &str) -> usize {
-  1 + s.as_bytes().len() + 2
+pub fn simplestring_encode_len(s: &[u8]) -> usize {
+  1 + s.len() + 2
 }
 
 pub fn verbatimstring_encode_len(format: &VerbatimStringFormat, data: &[u8]) -> usize {
@@ -204,7 +204,7 @@ pub fn encode_len(data: &Frame) -> Result<usize, GenError> {
     SimpleError {
       ref data,
       ref attributes,
-    } => simplestring_encode_len(data) + attribute_encode_len(attributes)?,
+    } => simplestring_encode_len(data.as_bytes()) + attribute_encode_len(attributes)?,
     Number {
       ref data,
       ref attributes,
@@ -284,7 +284,10 @@ pub fn reconstruct_blobstring(
     });
   }
 
-  Ok(Frame::BlobString { data, attributes })
+  Ok(Frame::BlobString {
+    data: data.freeze(),
+    attributes,
+  })
 }
 
 pub fn reconstruct_array(frames: VecDeque<Frame>, attributes: Option<Attributes>) -> Result<Frame, RedisProtocolError> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -188,6 +188,18 @@ where
   }
 }
 
+impl<B> From<BytesUtf8Error<B>> for RedisProtocolError {
+  fn from(e: BytesUtf8Error<B>) -> Self {
+    e.utf8_error().into()
+  }
+}
+
+impl From<Utf8Error> for RedisProtocolError {
+  fn from(e: Utf8Error) -> Self {
+    RedisProtocolError::new(RedisProtocolErrorKind::DecodeError, format!("{}", e))
+  }
+}
+
 /// A struct defining parse errors when decoding frames.
 pub enum RedisParseError<I> {
   Custom {
@@ -236,6 +248,16 @@ impl<I> ParseError<I> for RedisParseError<I> {
   }
 
   fn append(_: I, _: ErrorKind, other: Self) -> Self {
+    other
+  }
+}
+
+impl<I, O> ParseError<(I, O)> for RedisParseError<I> {
+  fn from_error_kind(input: (I, O), kind: ErrorKind) -> Self {
+    RedisParseError::Nom(input.0, kind)
+  }
+
+  fn append(_: (I, O), _: ErrorKind, other: Self) -> Self {
     other
   }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -268,6 +268,12 @@ impl<I, E> FromExternalError<I, E> for RedisParseError<I> {
   }
 }
 
+impl<I, O, E> FromExternalError<(I, O), E> for RedisParseError<I> {
+  fn from_external_error(input: (I, O), kind: ErrorKind, _e: E) -> Self {
+    RedisParseError::Nom(input.0, kind)
+  }
+}
+
 impl<I> From<nom::Err<RedisParseError<I>>> for RedisParseError<I> {
   fn from(e: NomError<RedisParseError<I>>) -> Self {
     match e {

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,8 +8,13 @@ use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
 use std::io::Error as IoError;
+use std::ops::{Deref, DerefMut};
 
+use bytes::BytesMut;
+use bytes_utils::SegmentedBuf;
 use std::str;
+
+pub use crate::nom_bytes::*;
 
 /// Terminating bytes between frames.
 pub const CRLF: &'static str = "\r\n";

--- a/src/types.rs
+++ b/src/types.rs
@@ -271,7 +271,7 @@ impl Redirection {
       Redirection::Ask { ref slot, ref server } => format!("ASK {} {}", slot, server),
     };
 
-    Resp2Frame::Error(inner)
+    Resp2Frame::Error(inner.into())
   }
 
   pub fn to_resp3_frame(&self) -> Resp3Frame {
@@ -281,7 +281,7 @@ impl Redirection {
     };
 
     Resp3Frame::SimpleError {
-      data: inner,
+      data: inner.into(),
       attributes: None,
     }
   }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 use crate::resp2::types::Frame as Resp2Frame;
 use crate::resp3::types::Frame as Resp3Frame;
-
 use cookie_factory::GenError;
 use nom::error::{ErrorKind, FromExternalError, ParseError};
 use nom::{Err as NomError, Needed};
@@ -8,13 +7,7 @@ use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
 use std::io::Error as IoError;
-use std::ops::{Deref, DerefMut};
-
-use bytes::BytesMut;
-use bytes_utils::SegmentedBuf;
 use std::str;
-
-pub use crate::nom_bytes::*;
 
 /// Terminating bytes between frames.
 pub const CRLF: &'static str = "\r\n";

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use crate::resp2::types::Frame as Resp2Frame;
 use crate::resp3::types::Frame as Resp3Frame;
 use crate::types::*;
 use bytes::BytesMut;
-use bytes_utils::{Str, StrMut};
+use bytes_utils::Str;
 use cookie_factory::GenError;
 use crc16::{State, XMODEM};
 use nom::error::ErrorKind as NomErrorKind;
@@ -51,7 +51,7 @@ macro_rules! encode_checks(
 
 macro_rules! e (
   ($err:expr) => {
-    return Err($err.into_nom_error())
+    return Err(RedisParseError::from($err).into_nom_error())
   }
 );
 
@@ -59,7 +59,7 @@ macro_rules! etry (
   ($expr:expr) => {
     match $expr {
       Ok(result) => result,
-      Err(e) => return Err(e.into_nom_error())
+      Err(e) => return Err(RedisParseError::from(e).into_nom_error())
     }
   }
 );
@@ -70,6 +70,16 @@ macro_rules! decode_log(
     if log_enabled!(log::Level::Trace) {
       if let Some(s) = std::str::from_utf8(&$buf).ok() {
         let $buf = s;
+        trace!($($arg)*)
+      }else{
+        trace!($($arg)*)
+      }
+    }
+  );
+  ($buf:expr, $name:ident, $($arg:tt)*) => (
+    if log_enabled!(log::Level::Trace) {
+      if let Some(s) = std::str::from_utf8(&$buf).ok() {
+        let $name = s;
         trace!($($arg)*)
       }else{
         trace!($($arg)*)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ macro_rules! etry (
 macro_rules! decode_log(
   ($buf:ident, $($arg:tt)*) => (
     if log_enabled!(log::Level::Trace) {
-      if let Some(s) = str::from_utf8(&$buf).ok() {
+      if let Some(s) = std::str::from_utf8(&$buf).ok() {
         let $buf = s;
         trace!($($arg)*)
       }else{

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,8 +2,10 @@ use crate::resp2::types::Frame as Resp2Frame;
 use crate::resp3::types::Frame as Resp3Frame;
 use crate::types::*;
 use bytes::BytesMut;
+use bytes_utils::StrMut;
 use cookie_factory::GenError;
 use crc16::{State, XMODEM};
+use nom::error::ErrorKind as NomErrorKind;
 use std::str;
 
 pub const KB: usize = 1024;
@@ -318,6 +320,15 @@ pub fn redis_keyslot(key: &[u8]) -> u16 {
   };
 
   out
+}
+
+pub(crate) fn to_strmut<T>(data: T) -> Result<StrMut, RedisParseError<NomBytesMut>>
+where
+  T: AsRef<NomBytesMut>,
+{
+  let data_ref = data.as_ref();
+  StrMut::from_inner(data_ref.clone().into_bytes())
+    .map_err(|error| RedisParseError::Nom(data_ref.clone(), NomErrorKind::ParseTo))
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,21 @@ macro_rules! encode_checks(
   }
 );
 
+macro_rules! e (
+  ($err:expr) => {
+    return Err($err.into_nom_error())
+  }
+);
+
+macro_rules! etry (
+  ($expr:expr) => {
+    match $expr {
+      Ok(result) => result,
+      Err(e) => return Err(e.into_nom_error())
+    }
+  }
+);
+
 /// Utility function to translate RESP2 frames to RESP3 frames.
 ///
 /// RESP2 frames and RESP3 frames are quite different, but RESP3 is largely a superset of RESP2 so this function will never return an error.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -61,6 +61,31 @@ macro_rules! etry (
   }
 );
 
+#[cfg(feature = "decode-logs")]
+macro_rules! decode_log(
+  ($buf:ident, $($arg:tt)*) => (
+    if log_enabled!(log::Level::Trace) {
+      if let Some(s) = str::from_utf8(&$buf).ok() {
+        let $buf = s;
+        trace!($($arg)*)
+      }else{
+        trace!($($arg)*)
+      }
+    }
+  );
+  ($($arg:tt)*) => (
+    if log_enabled!(log::Level::Trace) {
+      trace!($($arg)*)
+    }
+  );
+);
+
+#[cfg(not(feature = "decode-logs"))]
+macro_rules! decode_log(
+  ($buf:ident, $($arg:tt)*) => ();
+  ($($arg:tt)*) => ();
+);
+
 /// Utility function to translate RESP2 frames to RESP3 frames.
 ///
 /// RESP2 frames and RESP3 frames are quite different, but RESP3 is largely a superset of RESP2 so this function will never return an error.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -323,7 +323,7 @@ pub fn redis_keyslot(key: &[u8]) -> u16 {
   out
 }
 
-pub(crate) fn to_strmut<T>(data: T) -> Result<Str, RedisParseError<NomBytes>>
+pub(crate) fn to_byte_str<T>(data: T) -> Result<Str, RedisParseError<NomBytes>>
 where
   T: AsRef<NomBytes>,
 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,11 +58,11 @@ pub fn resp2_frame_to_resp3(frame: Resp2Frame) -> Resp3Frame {
   if frame.is_normal_pubsub() {
     let mut out = Vec::with_capacity(4);
     out.push(Resp3Frame::SimpleString {
-      data: PUBSUB_PUSH_PREFIX.to_owned(),
+      data: PUBSUB_PUSH_PREFIX.into(),
       attributes: None,
     });
     out.push(Resp3Frame::SimpleString {
-      data: PUBSUB_PREFIX.to_owned(),
+      data: PUBSUB_PREFIX.into(),
       attributes: None,
     });
     if let Resp2Frame::Array(mut inner) = frame {
@@ -83,11 +83,11 @@ pub fn resp2_frame_to_resp3(frame: Resp2Frame) -> Resp3Frame {
   if frame.is_pattern_pubsub_message() {
     let mut out = Vec::with_capacity(4);
     out.push(Resp3Frame::SimpleString {
-      data: PUBSUB_PUSH_PREFIX.to_owned(),
+      data: PUBSUB_PUSH_PREFIX.into(),
       attributes: None,
     });
     out.push(Resp3Frame::SimpleString {
-      data: PATTERN_PUBSUB_PREFIX.to_owned(),
+      data: PATTERN_PUBSUB_PREFIX.into(),
       attributes: None,
     });
     if let Resp2Frame::Array(mut inner) = frame {
@@ -159,104 +159,6 @@ pub fn resp2_frame_to_resp3(frame: Resp2Frame) -> Resp3Frame {
         attributes: None,
       }
     }
-  }
-}
-
-/// Utility function for converting RESP3 frames back to RESP2 frames.
-///
-/// RESP2 has no concept of attributes, maps, blob errors, or certain other frames. The following policy is used for translating new RESP3 frames back to RESP2:
-///
-/// * Push - If the Push frame corresponds to a pubsub message then it's converted to an array, otherwise an error is returned.
-/// * BlobError - An error is returned since the inner bytes might not be a UTF8 string, or they might be too large for a RESP2 SimpleError.
-/// * BigNumber - This is converted to a RESP2 BulkString
-/// * Boolean - This is converted to a BulkString with values of `true` or `false`. The associated [resp2_frame_to_resp3] function will convert back to Boolean from these values.
-/// * Double - The inner floating point value is converted to a `String` and sent as a BulkString.
-/// * VerbatimString - The inner data is sent as a BulkString. The format is discarded.
-/// * Set - The inner data is sent as an Array.
-/// * Map - An error is returned. RESP2 has no concept of a map.
-/// * Hello - An error is returned. If the caller wants to send Hello it needs to be encoded manually.
-/// * ChunkedString - An error is returned. RESP2 has no concept of streaming strings.
-///
-/// **Calling this with any RESP3 frame with attributes will result in an error.**
-///
-/// As seen above the conversion from RESP3 to RESP2 is lossy and error-prone, so callers are encouraged to use [resp2_frame_to_resp3] instead by exposing the RESP3 interface up
-/// the stack even if RESP2 decoding functions are used.
-pub fn resp3_frame_to_resp2(frame: Resp3Frame) -> Result<Resp2Frame, RedisProtocolError> {
-  if frame.attributes().is_some() {
-    return Err(RedisProtocolError::new(
-      RedisProtocolErrorKind::Unknown,
-      "Cannot convert RESP3 frame with attributes to RESP2.",
-    ));
-  }
-
-  if frame.is_pubsub_message() {
-    let mut out = Vec::with_capacity(3);
-    out.push(Resp2Frame::SimpleString(PUBSUB_PREFIX.to_owned()));
-
-    if let Resp3Frame::Push { mut data, .. } = frame {
-      // unwrap checked in is_normal_pubsub
-      let message = data.pop().unwrap();
-      let channel = data.pop().unwrap();
-
-      out.push(resp3_frame_to_resp2(channel)?);
-      out.push(resp3_frame_to_resp2(message)?);
-    } else {
-      panic!("Invalid pubsub frame converting to resp2 frame.");
-    }
-
-    return Ok(Resp2Frame::Array(out));
-  }
-
-  match frame {
-    Resp3Frame::Array { data, .. } => {
-      let mut out = Vec::with_capacity(data.len());
-      for frame in data.into_iter() {
-        out.push(resp3_frame_to_resp2(frame)?);
-      }
-      Ok(Resp2Frame::Array(out))
-    }
-    Resp3Frame::Push { data: _, .. } => Err(RedisProtocolError::new(
-      RedisProtocolErrorKind::Unknown,
-      "Cannot convert non-pubsub PUSH frame to RESP2 frame.",
-    )),
-    Resp3Frame::BlobString { data, .. } => Ok(Resp2Frame::BulkString(data)),
-    Resp3Frame::BlobError { data: _, .. } => Err(RedisProtocolError::new(
-      RedisProtocolErrorKind::Unknown,
-      "Cannot convert BlobError to RESP2 frame.",
-    )),
-    Resp3Frame::BigNumber { data, .. } => Ok(Resp2Frame::BulkString(data)),
-    Resp3Frame::Boolean { data, .. } => {
-      if data {
-        Ok(Resp2Frame::BulkString("true".into()))
-      } else {
-        Ok(Resp2Frame::BulkString("false".into()))
-      }
-    }
-    Resp3Frame::Number { data, .. } => Ok(Resp2Frame::Integer(data)),
-    Resp3Frame::Double { data, .. } => Ok(Resp2Frame::BulkString(data.to_string().into_bytes())),
-    Resp3Frame::VerbatimString { data, .. } => Ok(Resp2Frame::BulkString(data)),
-    Resp3Frame::SimpleError { data, .. } => Ok(Resp2Frame::Error(data)),
-    Resp3Frame::SimpleString { data, .. } => Ok(Resp2Frame::SimpleString(data)),
-    Resp3Frame::Set { data, .. } => {
-      let mut out = Vec::with_capacity(data.len());
-      for frame in data.into_iter() {
-        out.push(resp3_frame_to_resp2(frame)?);
-      }
-      Ok(Resp2Frame::Array(out))
-    }
-    Resp3Frame::Map { data: _, .. } => Err(RedisProtocolError::new(
-      RedisProtocolErrorKind::Unknown,
-      "Cannot convert Map to RESP2 frame.",
-    )),
-    Resp3Frame::Null => Ok(Resp2Frame::Null),
-    Resp3Frame::ChunkedString(_) => Err(RedisProtocolError::new(
-      RedisProtocolErrorKind::Unknown,
-      "Cannot convert ChunkedString to RESP2 frame.",
-    )),
-    Resp3Frame::Hello { .. } => Err(RedisProtocolError::new(
-      RedisProtocolErrorKind::Unknown,
-      "Cannot convert HELLO to RESP2 frame.",
-    )),
   }
 }
 
@@ -342,7 +244,6 @@ fn crc16_xmodem(key: &[u8]) -> u16 {
 /// # use redis_protocol::redis_keyslot;
 /// assert_eq!(redis_keyslot("8xjx7vWrfPq54mKfFD3Y1CcjjofpnAcQ".as_bytes()), 5458);
 /// ```
-#[cfg(feature = "cluster-hash-bytes")]
 pub fn redis_keyslot(key: &[u8]) -> u16 {
   let (mut i, mut j): (Option<usize>, Option<usize>) = (None, None);
 
@@ -379,70 +280,10 @@ pub fn redis_keyslot(key: &[u8]) -> u16 {
   out
 }
 
-/// Map a Redis key to its cluster key slot.
-///
-/// ```ignore
-/// $ redis-cli -p 30001 cluster keyslot "8xjx7vWrfPq54mKfFD3Y1CcjjofpnAcQ"
-/// (integer) 5458
-/// ```
-///
-/// ```no_run
-/// # use redis_protocol::redis_keyslot;
-/// assert_eq!(redis_keyslot("8xjx7vWrfPq54mKfFD3Y1CcjjofpnAcQ"), 5458);
-/// ```
-#[cfg(not(feature = "cluster-hash-bytes"))]
-pub fn redis_keyslot(key: &str) -> u16 {
-  let (mut i, mut j): (Option<usize>, Option<usize>) = (None, None);
-
-  for (idx, c) in key.chars().enumerate() {
-    if c == '{' {
-      i = Some(idx);
-      break;
-    }
-  }
-
-  if i.is_none() || (i.is_some() && i.unwrap() == key.len() - 1) {
-    return crc16_xmodem(key.as_bytes());
-  }
-
-  let i = i.unwrap();
-  for (idx, c) in key[i + 1..].chars().enumerate() {
-    if c == '}' {
-      j = Some(idx);
-      break;
-    }
-  }
-
-  if j.is_none() {
-    return crc16_xmodem(key.as_bytes());
-  }
-
-  let j = j.unwrap();
-  let out = if i + j == key.len() || j == 0 {
-    crc16_xmodem(key.as_bytes())
-  } else {
-    crc16_xmodem(key[i + 1..i + j + 1].as_bytes())
-  };
-
-  trace!("mapped {} to redis slot {}", key, out);
-  out
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
 
-  #[cfg(feature = "cluster-hash-bytes")]
-  fn _redis_keyslot(key: &str) -> u16 {
-    redis_keyslot(key.as_bytes())
-  }
-
-  #[cfg(not(feature = "cluster-hash-bytes"))]
-  fn _redis_keyslot(key: &str) -> u16 {
-    redis_keyslot(key)
-  }
-
-  #[cfg(feature = "cluster-hash-bytes")]
   fn read_kitten_file() -> Vec<u8> {
     include_bytes!("../tests/kitten.jpeg").to_vec()
   }
@@ -452,7 +293,7 @@ mod tests {
     let key = "123456789";
     // 31C3
     let expected: u16 = 12739;
-    let actual = _redis_keyslot(key);
+    let actual = redis_keyslot(key.as_bytes());
 
     assert_eq!(actual, expected);
   }
@@ -462,7 +303,7 @@ mod tests {
     let key = "foo{123456789}bar";
     // 31C3
     let expected: u16 = 12739;
-    let actual = _redis_keyslot(key);
+    let actual = redis_keyslot(key.as_bytes());
 
     assert_eq!(actual, expected);
   }
@@ -472,7 +313,7 @@ mod tests {
     let key = "{123456789}";
     // 31C3
     let expected: u16 = 12739;
-    let actual = _redis_keyslot(key);
+    let actual = redis_keyslot(key.as_bytes());
 
     assert_eq!(actual, expected);
   }
@@ -482,7 +323,7 @@ mod tests {
     let key = "foo{123456789";
     // 288A
     let expected: u16 = 10378;
-    let actual = _redis_keyslot(key);
+    let actual = redis_keyslot(key.as_bytes());
 
     assert_eq!(actual, expected);
   }
@@ -492,7 +333,7 @@ mod tests {
     let key = "foo}123456789";
     // 5B35 = 23349, 23349 % 16384 = 6965
     let expected: u16 = 6965;
-    let actual = _redis_keyslot(key);
+    let actual = redis_keyslot(key.as_bytes());
 
     assert_eq!(actual, expected);
   }
@@ -503,12 +344,11 @@ mod tests {
     // 127.0.0.1:30001> cluster keyslot 8xjx7vWrfPq54mKfFD3Y1CcjjofpnAcQ
     // (integer) 5458
     let expected: u16 = 5458;
-    let actual = _redis_keyslot(key);
+    let actual = redis_keyslot(key.as_bytes());
 
     assert_eq!(actual, expected);
   }
 
-  #[cfg(feature = "cluster-hash-bytes")]
   #[test]
   fn should_hash_non_ascii_string_bytes() {
     let key = "💩 👻 💀 ☠️ 👽 👾";
@@ -520,7 +360,6 @@ mod tests {
     assert_eq!(actual, expected);
   }
 
-  #[cfg(feature = "cluster-hash-bytes")]
   #[test]
   fn should_hash_non_ascii_string_bytes_with_tag() {
     let key = "💩 👻 💀{123456789}☠️ 👽 👾";
@@ -532,7 +371,6 @@ mod tests {
     assert_eq!(actual, expected);
   }
 
-  #[cfg(feature = "cluster-hash-bytes")]
   #[test]
   fn should_hash_non_utf8_string_bytes() {
     let key = read_kitten_file();
@@ -542,7 +380,6 @@ mod tests {
     assert_eq!(actual, expected)
   }
 
-  #[cfg(feature = "cluster-hash-bytes")]
   #[test]
   fn should_hash_non_utf8_string_bytes_with_tag() {
     let mut key = read_kitten_file();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::nom_bytes::NomBytesMut;
 use crate::resp2::types::Frame as Resp2Frame;
 use crate::resp3::types::Frame as Resp3Frame;
 use crate::types::*;
@@ -328,7 +329,7 @@ where
 {
   let data_ref = data.as_ref();
   StrMut::from_inner(data_ref.clone().into_bytes())
-    .map_err(|error| RedisParseError::Nom(data_ref.clone(), NomErrorKind::ParseTo))
+    .map_err(|_| RedisParseError::Nom(data_ref.clone(), NomErrorKind::ParseTo))
 }
 
 #[cfg(test)]

--- a/tests/doc.sh
+++ b/tests/doc.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo +nightly rustdoc --all-features "$@" -- --cfg docsrs


### PR DESCRIPTION
* Switch decoder interface to use `Bytes`
* Switch `Frame` types to use `Bytes`/`Str`.
* Add `decode_mut` interface
* Update docs, tests
* Fix https://github.com/aembke/redis-protocol.rs/issues/18