### PR TITLE
no_std support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,24 @@ jobs:
       - run:
           name: Run tests with indexmap features
           command: cargo clean && eval `ssh-agent` && ssh-add ~/.ssh/id_rsa && cargo test --release --features decode-mut
+  build_no_std:
+    docker:
+      - image: cimg/rust:1.57.0
+    steps:
+      - checkout
+      - run:
+          name: Switch to nightly for using unstable feature avoid-dev-deps
+          command: rustup default nightly
+      - run:
+          name: Clear the cargo git cache
+          command: rm -rf ~/.cargo/git/* && rm -rf ~/.cargo/registry/cache/*
+      - run:
+          name: Add cross compile target
+          command: rustup target add thumbv7m-none-eabi
+      - run:
+          name: Verifies successful build for no_std target
+          command: cargo clean && eval `ssh-agent` && ssh-add ~/.ssh/id_rsa && cargo build -Z avoid-dev-deps --release --no-default-features --features libm,hashbrown,alloc --target=thumbv7m-none-eabi
+
 
 workflows:
   version: 2
@@ -41,3 +59,4 @@ workflows:
       - tests-default
       - tests-indexmap
       - tests-decode-mut
+      - build_no_std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ repository = "aembke/redis-protocol.rs"
 
 [dependencies]
 bytes = { version = "1.1", default-features = false }
-# Tmp. needed until PR https://github.com/vorner/bytes-utils/pull/3 is merged
-bytes-utils = { git = "https://github.com/marius-meissner/bytes-utils", default-features = false, branch = "no_std_support" }
+bytes-utils = { version = "0.1.2", default-features = false }
 cookie-factory = { version = "0.3", default-features = false }
 crc16 = "0.4"
 indexmap = { version = "1.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Alec Embke <aembke@gmail.com>"]
 description = "Structs and functions to implement the Redis protocol."
 homepage = "https://github.com/aembke/redis-protocol.rs"
-keywords = ["redis", "protocol", "nom", "resp"]
+keywords = ["redis", "protocol", "nom", "resp", "no_std"]
 license = "MIT"
 name = "redis-protocol"
 readme = "README.md"
@@ -18,13 +18,16 @@ branch = "main"
 repository = "aembke/redis-protocol.rs"
 
 [dependencies]
-bytes = "1.1"
-bytes-utils = "0.1"
-cookie-factory = "0.3"
+bytes = { version = "1.1", default-features = false }
+# Tmp. needed until PR https://github.com/vorner/bytes-utils/pull/3 is merged
+bytes-utils = { git = "https://github.com/marius-meissner/bytes-utils", default-features = false, branch = "no_std_support" }
+cookie-factory = { version = "0.3", default-features = false }
 crc16 = "0.4"
 indexmap = { version = "1.6", optional = true }
 log = "0.4"
-nom = "7.1"
+nom = { version = "7.1", default-features = false }
+libm = { version = "0.2.2", optional = true }
+hashbrown = { version = "0.13.2", optional = true }
 
 [dev-dependencies]
 rand = "0.5"
@@ -34,10 +37,12 @@ itertools = "0.10"
 pretty_env_logger = "0.4"
 
 [features]
-default = []
+default = ["std"]
 index-map = ["indexmap"]
 decode-logs = []
 decode-mut = []
+alloc = ["nom/alloc"]
+std = ["bytes/default", "bytes-utils/std", "cookie-factory/default", "nom/default"]
 
 [lib]
 doc = true

--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ To better support this use case (such as the [codec](https://docs.rs/tokio-util/
 ## IndexMap
 
 Enable the `index-map` feature to use [IndexMap](https://crates.io/crates/indexmap) instead of `HashMap` and `HashSet`. This is useful for testing and may also be useful to callers.
+
+## no_std
+
+`no_std` builds are supported by disabling the `std` feature. However, a few optional dependencies must be activated as a substitute.
+
+````TOML
+redis-protocol = { version="X.X.X", default-features = false, features = ["libm", "hashbrown", "alloc"] }
+````

--- a/src/decode_mut/frame.rs
+++ b/src/decode_mut/frame.rs
@@ -1,9 +1,17 @@
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
 use crate::decode_mut::utils::hash_tuple;
 use crate::resp3::types::{Auth, FrameKind, RespVersion, VerbatimStringFormat, NULL};
 use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind};
 use nom::IResult;
+
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
+
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap, HashSet};
 
 pub type IndexFrameMap = HashMap<Resp3IndexFrame, Resp3IndexFrame>;
 pub type IndexAttributes = Option<IndexFrameMap>;

--- a/src/decode_mut/resp2.rs
+++ b/src/decode_mut/resp2.rs
@@ -5,6 +5,8 @@ use crate::resp2::types::{
   Frame as Resp2Frame, FrameKind, ARRAY_BYTE, BULKSTRING_BYTE, ERROR_BYTE, INTEGER_BYTE, SIMPLESTRING_BYTE,
 };
 use crate::types::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind, CRLF};
+use crate::alloc::string::ToString;
+use alloc::vec::Vec;
 use bytes::{Bytes, BytesMut};
 use bytes_utils::Str;
 use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
@@ -12,7 +14,7 @@ use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
 use nom::{AsBytes, Err as NomErr};
-use std::str;
+use core::str;
 
 pub fn to_isize(s: &[u8]) -> Result<isize, RedisParseError<&[u8]>> {
   str::from_utf8(s)?

--- a/src/decode_mut/resp3.rs
+++ b/src/decode_mut/resp3.rs
@@ -16,8 +16,13 @@ use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
 use nom::{AsBytes, Err as NomErr};
+use core::str;
+
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
-use std::str;
+
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap, HashSet};
 
 fn map_hello<'a>(frame: Resp3Frame) -> Result<Resp3IndexFrame, RedisParseError<&'a [u8]>> {
   match frame {

--- a/src/decode_mut/utils.rs
+++ b/src/decode_mut/utils.rs
@@ -1,6 +1,6 @@
 use crate::types::{RedisProtocolError, RedisProtocolErrorKind};
 use bytes::Bytes;
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 pub fn hash_tuple<H: Hasher>(state: &mut H, range: &(usize, usize)) {
   range.0.hash(state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
 //! # Redis Protocol
 //!
@@ -39,6 +40,9 @@
 //! ```
 //!
 //! Note: if callers are not using the `index-map` feature then substitute `std::collections::HashMap` for any `IndexMap` types in these docs. `rustdoc` doesn't have a great way to show type substitutions based on feature flags.
+
+extern crate alloc;
+extern crate core;
 
 #[macro_use]
 extern crate log;

--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -1,11 +1,10 @@
 use bytes::buf::IntoIter;
 use bytes::Bytes;
 use nom::{AsBytes, FindSubstring, InputIter, InputLength, InputTake, Needed, Offset, Slice, UnspecializedInput};
-use std::fmt::Debug;
-use std::iter::Enumerate;
-use std::ops::{Deref, DerefMut, Range, RangeFrom, RangeFull, RangeTo};
+use core::iter::Enumerate;
+use core::ops::{Deref, DerefMut, Range, RangeFrom, RangeFull, RangeTo};
 #[cfg(feature = "decode-logs")]
-use std::str;
+use core::str;
 
 /// A wrapper type for `Bytes` that implements the Nom traits necessary to operate on Bytes slices directly with nom functions.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -6,13 +6,14 @@ use crate::nom_bytes::NomBytes;
 use crate::resp2::types::*;
 use crate::types::*;
 use crate::utils;
+use alloc::vec::Vec;
 use bytes::Bytes;
 use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
 use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
 use nom::{Err as NomErr, IResult};
-use std::str;
+use core::str;
 
 pub(crate) const NULL_LEN: isize = -1;
 

--- a/src/resp2/encode.rs
+++ b/src/resp2/encode.rs
@@ -6,6 +6,8 @@ use crate::resp2::types::*;
 use crate::resp2::utils::{self as resp2_utils};
 use crate::types::{RedisProtocolError, CRLF};
 use crate::utils;
+use crate::alloc::string::ToString;
+use alloc::vec::Vec;
 use bytes::BytesMut;
 use cookie_factory::GenError;
 

--- a/src/resp2/types.rs
+++ b/src/resp2/types.rs
@@ -1,10 +1,12 @@
 use crate::resp2::utils as resp2_utils;
 use crate::types::{Redirection, RedisProtocolError};
 use crate::utils;
+use alloc::string::String;
+use alloc::vec::Vec;
 use bytes::Bytes;
 use bytes_utils::Str;
-use std::mem;
-use std::str;
+use core::mem;
+use core::str;
 
 /// Byte prefix before a simple string type.
 pub const SIMPLESTRING_BYTE: u8 = b'+';

--- a/src/resp2/utils.rs
+++ b/src/resp2/utils.rs
@@ -1,5 +1,7 @@
 use crate::resp2::types::{Frame, FrameKind, NULL};
 use crate::utils::{digits_in_number, PATTERN_PUBSUB_PREFIX, PUBSUB_PREFIX};
+use alloc::string::String;
+use alloc::vec::Vec;
 use cookie_factory::GenError;
 
 pub fn bulkstring_encode_len(b: &[u8]) -> usize {

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -7,6 +7,8 @@ use crate::resp3::types::*;
 use crate::resp3::utils as resp3_utils;
 use crate::types::*;
 use crate::utils;
+use alloc::format;
+use alloc::vec::Vec;
 use bytes_utils::Str;
 use nom::bytes::streaming::{take as nom_take, take_until as nom_take_until};
 use nom::combinator::{map as nom_map, map_res as nom_map_res, opt as nom_opt};
@@ -14,8 +16,8 @@ use nom::multi::count as nom_count;
 use nom::number::streaming::be_u8;
 use nom::sequence::terminated as nom_terminated;
 use nom::{Err as NomErr, IResult};
-use std::fmt::Debug;
-use std::str;
+use core::fmt::Debug;
+use core::str;
 
 fn map_complete_frame(frame: Frame) -> DecodedFrame {
   DecodedFrame::Complete(frame)

--- a/src/resp3/encode.rs
+++ b/src/resp3/encode.rs
@@ -6,6 +6,8 @@ use crate::resp3::types::*;
 use crate::resp3::utils::{self as resp3_utils};
 use crate::types::{RedisProtocolError, RedisProtocolErrorKind, CRLF};
 use crate::utils;
+use crate::alloc::string::ToString;
+use alloc::vec::Vec;
 use bytes::BytesMut;
 use cookie_factory::GenError;
 

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -1,13 +1,22 @@
 use crate::resp3::utils as resp3_utils;
 use crate::types::{Redirection, RedisProtocolError, RedisProtocolErrorKind};
 use crate::utils;
+use alloc::collections::VecDeque;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use bytes::Bytes;
 use bytes_utils::Str;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::TryFrom;
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::str;
+use core::convert::TryFrom;
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::str;
+
+#[cfg(feature = "std")]
+use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap, HashSet};
 
 #[cfg(feature = "index-map")]
 use indexmap::{IndexMap, IndexSet};

--- a/src/resp3/utils.rs
+++ b/src/resp3/utils.rs
@@ -1,10 +1,19 @@
 use crate::resp3::types::*;
 use crate::types::{RedisProtocolError, RedisProtocolErrorKind};
 use crate::utils::{digits_in_number, PATTERN_PUBSUB_PREFIX, PUBSUB_PREFIX, PUBSUB_PUSH_PREFIX};
+use alloc::borrow::Cow;
+use alloc::collections::VecDeque;
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use bytes::BytesMut;
 use cookie_factory::GenError;
-use std::borrow::Cow;
-use std::collections::{HashMap, HashSet, VecDeque};
+
+#[cfg(feature = "std")]
+use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap, HashSet};
 
 #[cfg(feature = "index-map")]
 use indexmap::{IndexMap, IndexSet};
@@ -361,6 +370,7 @@ pub fn reconstruct_set(frames: VecDeque<Frame>, attributes: Option<Attributes>) 
 
 #[cfg(test)]
 mod tests {
+  use alloc::vec;
   use crate::resp3::types::*;
   use crate::resp3::utils::{encode_len, new_map, new_set};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,9 @@ use bytes_utils::Str;
 use cookie_factory::GenError;
 use crc16::{State, XMODEM};
 use nom::error::ErrorKind as NomErrorKind;
-use std::str;
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use core::str;
 
 pub const KB: usize = 1024;
 /// A pre-defined zeroed out KB of data, used to speed up extending buffers while encoding.
@@ -225,12 +227,22 @@ pub fn check_offset(x: &(&mut [u8], usize)) -> Result<(), GenError> {
 }
 
 /// Returns the number of bytes necessary to encode a string representation of `d`.
+#[cfg(feature = "std")]
 pub fn digits_in_number(d: usize) -> usize {
   if d == 0 {
     return 1;
   }
 
   ((d as f64).log10()).floor() as usize + 1
+}
+
+#[cfg(feature = "libm")]
+pub fn digits_in_number(d: usize) -> usize {
+  if d == 0 {
+    return 1;
+  }
+
+  libm::floor(libm::log10(d as f64)) as usize + 1
 }
 
 // this is faster than repeat(0).take(amt) at the cost of some memory


### PR DESCRIPTION
This is an awesome crate, but unfortunately fails to build on no_std projects.
This PR adds support for no_std builds by adding a std feature, which when is disabled enables no_std environments.

~~**bytes-utils dependency**~~
~~To make this work, a similar change for bytes-utils was needed: https://github.com/vorner/bytes-utils/pull/3
So I just pointed `Cargo.toml` to the PR fork~~.
~~Feel free to suggest another approach if you are not happy with that (e.g. pinning to hash, using dependency patch, just wait for the other PR, etc.).~~

**Code formatting**
Seems `cargo fmt` was not executed for a while. So I skipped this step for not messing up this PR with code style changes.

**Circle CI**
In my opinion, it makes sense to add a CI step to check for successful no_std builds.
Unfortunately, cargo always compiles dev dependencies, even for release builds. Cargo flag [avoid-dev-deps](https://doc.rust-lang.org/cargo/reference/unstable.html#avoid-dev-deps) is fixing this, but is still unstable. So the CI job is testing only nighly Rust for now.

Looking forward to your feedback! 