### PR TITLE
Fix clippy lints

### DIFF
--- a/src/nom_bytes.rs
+++ b/src/nom_bytes.rs
@@ -44,7 +44,7 @@ impl DerefMut for NomBytes {
 
 impl AsRef<NomBytes> for NomBytes {
   fn as_ref(&self) -> &NomBytes {
-    &self
+    self
   }
 }
 

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -183,7 +183,7 @@ pub mod tests {
   use nom::AsBytes;
   use std::str;
 
-  pub const PADDING: &'static str = "FOOBARBAZ";
+  pub const PADDING: &str = "FOOBARBAZ";
 
   pub fn pretty_print_panic(e: RedisProtocolError) {
     panic!("{:?}", e);
@@ -194,7 +194,7 @@ pub mod tests {
   }
 
   fn decode_and_verify_some(bytes: &Bytes, expected: &(Option<Frame>, usize)) {
-    let (frame, len) = match decode(&bytes) {
+    let (frame, len) = match decode(bytes) {
       Ok(Some((f, l))) => (Some(f), l),
       Ok(None) => return panic_no_decode(),
       Err(e) => return pretty_print_panic(e),
@@ -220,7 +220,7 @@ pub mod tests {
   }
 
   fn decode_and_verify_none(bytes: &Bytes) {
-    let (frame, len) = match decode(&bytes) {
+    let (frame, len) = match decode(bytes) {
       Ok(Some((f, l))) => (Some(f), l),
       Ok(None) => (None, 0),
       Err(e) => return pretty_print_panic(e),
@@ -351,6 +351,6 @@ pub mod tests {
   #[should_panic]
   fn should_error_on_junk() {
     let bytes: Bytes = "foobarbazwibblewobble".into();
-    let _ = decode(&bytes).map_err(|e| pretty_print_panic(e));
+    let _ = decode(&bytes).map_err(pretty_print_panic);
   }
 }

--- a/src/resp2/encode.rs
+++ b/src/resp2/encode.rs
@@ -69,8 +69,8 @@ fn gen_array<'a>(x: (&'a mut [u8], usize), data: &Vec<Frame>) -> Result<(&'a mut
 
   for frame in data.iter() {
     x = match frame {
-      Frame::SimpleString(ref s) => gen_simplestring(x, &s)?,
-      Frame::BulkString(ref b) => gen_bulkstring(x, &b)?,
+      Frame::SimpleString(ref s) => gen_simplestring(x, s)?,
+      Frame::BulkString(ref b) => gen_bulkstring(x, b)?,
       Frame::Null => gen_null(x)?,
       Frame::Error(ref s) => gen_error(x, s)?,
       Frame::Array(ref frames) => gen_array(x, frames)?,
@@ -122,7 +122,7 @@ mod tests {
   use super::*;
   use crate::utils::*;
 
-  const PADDING: &'static str = "foobar";
+  const PADDING: &str = "foobar";
 
   fn encode_and_verify_empty(input: &Frame, expected: &str) {
     let mut buf = BytesMut::new();
@@ -144,7 +144,7 @@ mod tests {
       Ok(l) => l,
       Err(e) => panic!("{:?}", e),
     };
-    let padded = vec![PADDING, expected].join("");
+    let padded = [PADDING, expected].join("");
 
     assert_eq!(buf, padded.as_bytes(), "padded buf contents match");
     assert_eq!(len, padded.as_bytes().len(), "padded expected len is correct");

--- a/src/resp2/types.rs
+++ b/src/resp2/types.rs
@@ -20,7 +20,7 @@ pub const BULKSTRING_BYTE: u8 = b'$';
 pub const ARRAY_BYTE: u8 = b'*';
 
 /// The binary representation of NULL in RESP2.
-pub const NULL: &'static str = "$-1\r\n";
+pub const NULL: &str = "$-1\r\n";
 
 pub use crate::utils::{PATTERN_PUBSUB_PREFIX, PUBSUB_PREFIX};
 

--- a/src/resp2/utils.rs
+++ b/src/resp2/utils.rs
@@ -50,7 +50,7 @@ pub fn is_pattern_pubsub(frames: &Vec<Frame>) -> bool {
 /// Returns the number of bytes necessary to represent the frame.
 pub fn encode_len(data: &Frame) -> Result<usize, GenError> {
   match *data {
-    Frame::BulkString(ref b) => Ok(bulkstring_encode_len(&b)),
+    Frame::BulkString(ref b) => Ok(bulkstring_encode_len(b)),
     Frame::Array(ref frames) => array_encode_len(frames),
     Frame::Null => Ok(NULL.as_bytes().len()),
     Frame::SimpleString(ref s) => Ok(simplestring_encode_len(s)),

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -67,7 +67,7 @@ pub(crate) fn to_f64<T>(s: &[u8]) -> Result<f64, RedisParseError<T>> {
 }
 
 pub(crate) fn to_bool<T>(s: &[u8]) -> Result<bool, RedisParseError<T>> {
-  match str::from_utf8(s)?.as_ref() {
+  match str::from_utf8(s)? {
     "t" => Ok(true),
     "f" => Ok(false),
     _ => Err(RedisParseError::new_custom("to_bool", "Invalid boolean value.")),
@@ -75,7 +75,7 @@ pub(crate) fn to_bool<T>(s: &[u8]) -> Result<bool, RedisParseError<T>> {
 }
 
 pub(crate) fn to_verbatimstring_format<T>(s: &[u8]) -> Result<VerbatimStringFormat, RedisParseError<T>> {
-  match str::from_utf8(s)?.as_ref() {
+  match str::from_utf8(s)? {
     "txt" => Ok(VerbatimStringFormat::Text),
     "mkd" => Ok(VerbatimStringFormat::Markdown),
     _ => Err(RedisParseError::new_custom(
@@ -616,7 +616,7 @@ pub mod tests {
   use nom::AsBytes;
   use std::str;
 
-  pub const PADDING: &'static str = "FOOBARBAZ";
+  pub const PADDING: &str = "FOOBARBAZ";
 
   pub fn pretty_print_panic(e: RedisProtocolError) {
     panic!("{:?}", e);
@@ -627,7 +627,7 @@ pub mod tests {
   }
 
   fn decode_and_verify_some(bytes: &Bytes, expected: &(Option<Frame>, usize)) {
-    let (frame, len) = match complete::decode(&bytes) {
+    let (frame, len) = match complete::decode(bytes) {
       Ok(Some((f, l))) => (Some(f), l),
       Ok(None) => return panic_no_decode(),
       Err(e) => return pretty_print_panic(e),
@@ -653,7 +653,7 @@ pub mod tests {
   }
 
   fn decode_and_verify_none(bytes: &Bytes) {
-    let (frame, len) = match complete::decode(&bytes) {
+    let (frame, len) = match complete::decode(bytes) {
       Ok(Some((f, l))) => (Some(f), l),
       Ok(None) => (None, 0),
       Err(e) => return pretty_print_panic(e),
@@ -847,7 +847,7 @@ pub mod tests {
   #[should_panic]
   fn should_error_on_junk() {
     let bytes: Bytes = "foobarbazwibblewobble".into();
-    let _ = complete::decode(&bytes).map_err(|e| pretty_print_panic(e));
+    let _ = complete::decode(&bytes).map_err(pretty_print_panic);
   }
 
   // ----------------- end tests adapted from RESP2 ------------------------
@@ -1386,7 +1386,7 @@ pub mod tests {
             attributes: None,
           },
         ],
-        attributes: Some(expected_attrs.into()),
+        attributes: Some(expected_attrs),
       }),
       81,
     );

--- a/src/resp3/encode.rs
+++ b/src/resp3/encode.rs
@@ -647,8 +647,8 @@ pub mod streaming {
   }
 
   /// Encode the inner frames that make up a key-value pair in a streamed map.
-  pub fn encode_aggregate_type_inner_kv_pair<'a>(
-    buf: &'a mut [u8],
+  pub fn encode_aggregate_type_inner_kv_pair(
+    buf: &mut [u8],
     offset: usize,
     key: &Frame,
     value: &Frame,
@@ -690,7 +690,7 @@ mod tests {
   use std::convert::TryInto;
   use std::str;
 
-  const PADDING: &'static str = "foobar";
+  const PADDING: &str = "foobar";
 
   fn empty_bytes() -> BytesMut {
     BytesMut::new()
@@ -786,7 +786,7 @@ mod tests {
     buf.extend_from_slice(PADDING.as_bytes());
 
     let len = complete::encode_bytes(&mut buf, input).unwrap();
-    let padded = vec![PADDING, expected].join("");
+    let padded = [PADDING, expected].join("");
 
     assert_eq!(
       buf,
@@ -803,7 +803,7 @@ mod tests {
     buf.extend_from_slice(PADDING.as_bytes());
 
     let len = complete::encode_bytes(&mut buf, input).unwrap();
-    let expected_start_padded = vec![PADDING, expected_start].join("");
+    let expected_start_padded = [PADDING, expected_start].join("");
 
     unordered_assert_eq(buf, BytesMut::from(expected_start_padded.as_bytes()), expected_middle);
 
@@ -836,7 +836,7 @@ mod tests {
   fn encode_and_verify_empty_with_attributes(input: &Frame, expected: &str) {
     let (attributes, encoded_attributes) = create_attributes();
     let mut frame = input.clone();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     let mut buf = empty_bytes();
 
     let len = complete::encode_bytes(&mut buf, &frame).unwrap();
@@ -856,7 +856,7 @@ mod tests {
   fn encode_and_verify_empty_with_attributes_unordered(input: &Frame, expected_start: &str, expected_middle: &[&str]) {
     let (attributes, encoded_attributes) = create_attributes();
     let mut frame = input.clone();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     let mut buf = empty_bytes();
 
     let len = complete::encode_bytes(&mut buf, &frame).unwrap();
@@ -877,7 +877,7 @@ mod tests {
   fn encode_and_verify_non_empty_with_attributes(input: &Frame, expected: &str) {
     let (attributes, encoded_attributes) = create_attributes();
     let mut frame = input.clone();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
 
     let mut buf = empty_bytes();
     buf.extend_from_slice(PADDING.as_bytes());
@@ -903,7 +903,7 @@ mod tests {
   ) {
     let (attributes, encoded_attributes) = create_attributes();
     let mut frame = input.clone();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
 
     let mut buf = empty_bytes();
     buf.extend_from_slice(PADDING.as_bytes());
@@ -1085,7 +1085,7 @@ mod tests {
   #[test]
   fn should_encode_negative_number() {
     let expected = ":-1000\r\n";
-    let input: Frame = (-1000 as i64).into();
+    let input: Frame = (-1000_i64).into();
 
     encode_and_verify_empty(&input, expected);
     encode_and_verify_non_empty(&input, expected);

--- a/src/resp3/utils.rs
+++ b/src/resp3/utils.rs
@@ -283,7 +283,7 @@ pub fn reconstruct_blobstring(
   for frame in frames.into_iter() {
     data.extend_from_slice(match frame {
       Frame::ChunkedString(ref inner) => inner,
-      Frame::BlobString { ref data, .. } => &data,
+      Frame::BlobString { ref data, .. } => data,
       _ => {
         return Err(RedisProtocolError::new(
           RedisProtocolErrorKind::DecodeError,
@@ -327,7 +327,7 @@ pub fn reconstruct_map(
   }
 
   let mut data = new_map(Some(frames.len() / 2));
-  while frames.len() > 0 {
+  while !frames.is_empty() {
     let value = frames.pop_back().unwrap();
     let key = match frames.pop_back() {
       Some(f) => f,
@@ -522,7 +522,7 @@ mod tests {
     assert_eq!(streamed_frame.into_frame().unwrap(), expected);
 
     let (attributes, _) = create_attributes();
-    let _ = k1.add_attributes(attributes.clone()).unwrap();
+    k1.add_attributes(attributes.clone()).unwrap();
 
     let mut streamed_frame = StreamedFrame::new(FrameKind::Map);
     streamed_frame.add_frame(k1.clone());
@@ -602,7 +602,7 @@ mod tests {
     assert_eq!(streamed_frame.into_frame().unwrap(), expected);
 
     let (attributes, _) = create_attributes();
-    let _ = v1.add_attributes(attributes.clone()).unwrap();
+    v1.add_attributes(attributes.clone()).unwrap();
 
     let mut streamed_frame = StreamedFrame::new(FrameKind::Set);
     streamed_frame.add_frame(v1.clone());
@@ -779,8 +779,8 @@ mod tests {
     assert_eq!(streamed_frame.into_frame().unwrap(), expected);
 
     let (attributes, _) = create_attributes();
-    let _ = v1.add_attributes(attributes.clone()).unwrap();
-    let _ = inner_v1.add_attributes(attributes.clone()).unwrap();
+    v1.add_attributes(attributes.clone()).unwrap();
+    inner_v1.add_attributes(attributes.clone()).unwrap();
     let mut inner_map = new_map(None);
     inner_map.insert(inner_k1, inner_v1);
     let v2 = Frame::Map {
@@ -815,7 +815,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -829,7 +829,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -843,7 +843,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -857,7 +857,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
 
     let mut frame = Frame::Boolean {
@@ -868,7 +868,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -882,7 +882,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -896,7 +896,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -910,7 +910,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -924,7 +924,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -938,7 +938,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
 
     let mut frame = Frame::Double {
@@ -949,7 +949,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 
@@ -998,7 +998,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
 
     let mut frame = Frame::VerbatimString {
@@ -1010,7 +1010,7 @@ mod tests {
     assert_eq!(encode_len(&frame).unwrap(), expected_len);
 
     let (attributes, attributes_len) = create_attributes();
-    let _ = frame.add_attributes(attributes).unwrap();
+    frame.add_attributes(attributes).unwrap();
     assert_eq!(encode_len(&frame).unwrap(), expected_len + attributes_len);
   }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ use core::str::Utf8Error;
 use std::io::Error as IoError;
 
 /// Terminating bytes between frames.
-pub const CRLF: &'static str = "\r\n";
+pub const CRLF: &str = "\r\n";
 
 /// The kind of error without any associated data.
 #[derive(Debug)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,22 +13,22 @@ use core::str;
 
 pub const KB: usize = 1024;
 /// A pre-defined zeroed out KB of data, used to speed up extending buffers while encoding.
-pub const ZEROED_KB: &'static [u8; 1024] = &[0; 1024];
+pub const ZEROED_KB: &[u8; 1024] = &[0; 1024];
 
 pub const REDIS_CLUSTER_SLOTS: u16 = 16384;
 
 /// Prefix on normal pubsub messages.
 ///
 /// In RESP2 this may be the first inner frame, in RESP3 it may be the second inner frame.
-pub const PUBSUB_PREFIX: &'static str = "message";
+pub const PUBSUB_PREFIX: &str = "message";
 /// Prefix on pubsub messages from a pattern matching subscription.
 ///
 /// In RESP2 this may be the first inner frame, in RESP3 it may be the second inner frame.
-pub const PATTERN_PUBSUB_PREFIX: &'static str = "pmessage";
+pub const PATTERN_PUBSUB_PREFIX: &str = "pmessage";
 /// Prefix on RESP3 push pubsub messages.
 ///
 /// In RESP3 this is the first inner frame in a push pubsub message.
-pub const PUBSUB_PUSH_PREFIX: &'static str = "pubsub";
+pub const PUBSUB_PUSH_PREFIX: &str = "pubsub";
 
 macro_rules! unwrap_return(
   ($expr:expr) => {
@@ -173,7 +173,7 @@ pub fn resp2_frame_to_resp3(frame: Resp2Frame) -> Resp3Frame {
     Resp2Frame::BulkString(d) => {
       if d.len() < 6 {
         match str::from_utf8(&d).ok() {
-          Some(s) => match s.as_ref() {
+          Some(s) => match s {
             "true" => Resp3Frame::Boolean {
               data: true,
               attributes: None,
@@ -261,7 +261,7 @@ pub fn zero_extend(buf: &mut BytesMut, mut amt: usize) {
 
 pub fn is_cluster_error(payload: &str) -> bool {
   if payload.starts_with("MOVED") || payload.starts_with("ASK") {
-    payload.split(" ").fold(0, |c, _| c + 1) == 3
+    payload.split(' ').fold(0, |c, _| c + 1) == 3
   } else {
     false
   }
@@ -269,7 +269,7 @@ pub fn is_cluster_error(payload: &str) -> bool {
 
 pub fn read_cluster_error(payload: &str) -> Option<Redirection> {
   if payload.starts_with("MOVED") {
-    let parts: Vec<&str> = payload.split(" ").collect();
+    let parts: Vec<&str> = payload.split(' ').collect();
     if parts.len() == 3 {
       let slot = unwrap_return!(parts[1].parse::<u16>().ok());
       let server = parts[2].to_owned();
@@ -279,7 +279,7 @@ pub fn read_cluster_error(payload: &str) -> Option<Redirection> {
       None
     }
   } else if payload.starts_with("ASK") {
-    let parts: Vec<&str> = payload.split(" ").collect();
+    let parts: Vec<&str> = payload.split(' ').collect();
     if parts.len() == 3 {
       let slot = unwrap_return!(parts[1].parse::<u16>().ok());
       let server = parts[2].to_owned();
@@ -336,13 +336,13 @@ pub fn redis_keyslot(key: &[u8]) -> u16 {
   }
 
   let j = j.unwrap();
-  let out = if i + j == key.len() || j == 0 {
+  
+
+  if i + j == key.len() || j == 0 {
     crc16_xmodem(key)
   } else {
     crc16_xmodem(&key[i + 1..i + j + 1])
-  };
-
-  out
+  }
 }
 
 pub(crate) fn to_byte_str<T>(data: T) -> Result<Str, RedisParseError<NomBytes>>


### PR DESCRIPTION
A bunch of minor cleanups obtained by running `cargo clippy --fix`
I've inspected all of them and none of them affect functionality.