### PR TITLE
Add support for de/serializing Resp enums with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ log = "0.4"
 nom = { version = "7.1", default-features = false }
 libm = { version = "0.2", optional = true }
 hashbrown = { version = "0.14", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 
 [dev-dependencies]
@@ -50,7 +51,7 @@ index-map = ["indexmap"]
 bytes = ["dep:bytes", "bytes-utils"]
 decode-logs = []
 alloc = ["nom/alloc"]
-std = ["cookie-factory/default", "nom/default"]
+std = ["cookie-factory/default", "nom/default", "serde?/std"]
 codec = ["tokio-util", "bytes"]
 convert = []
 

--- a/src/resp3/types.rs
+++ b/src/resp3/types.rs
@@ -126,6 +126,8 @@ pub type RangeAttributes = FrameMap<RangeFrame, RangeFrame>;
 
 /// The RESP version used in the `HELLO` request.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "UPPERCASE"))]
 pub enum RespVersion {
   RESP2,
   RESP3,


### PR DESCRIPTION
Companion to https://github.com/aembke/fred.rs/pull/280

In order to de/serialize configuration types in `fred.rs`, `RespVersion` needs to implement `Serialize` and `Deserialize`.