### PR TITLE
Fix all valid feature combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ resp2 = [
 ]
 resp3 = ["nom/alloc"]
 index-map = ["dep:indexmap"]
-bytes = ["dep:bytes", "bytes-utils"]
+bytes = ["dep:bytes", "dep:bytes-utils"]
 decode-logs = []
 alloc = ["nom/alloc"]
 std = ["cookie-factory/default", "nom/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,21 +44,37 @@ criterion = { version = "0.4", features = ["html_reports"] }
 
 [features]
 default = ["std", "resp2", "resp3"]
-resp2 = []
-resp3 = []
-index-map = ["indexmap"]
+resp2 = [
+    "nom/alloc",
+    "resp3" # For some types
+]
+resp3 = ["nom/alloc"]
+index-map = ["dep:indexmap"]
 bytes = ["dep:bytes", "bytes-utils"]
 decode-logs = []
 alloc = ["nom/alloc"]
 std = ["cookie-factory/default", "nom/default"]
-codec = ["tokio-util", "bytes"]
+codec = ["dep:tokio-util", "bytes"]
 convert = []
+strict = []
 
 [lib]
 doc = true
 doctest = true
 name = "redis_protocol"
 test = true
+
+[package.metadata.cargo-all-features]
+# Note this requires https://github.com/frewsxcv/cargo-all-features/pull/50
+rules = [
+    "resp3 => (std|libm)",
+    "resp3 => ('index-map'|hashbrown|std)", # because otherwise types break
+    "convert => (hashbrown|std)", # convert doesn't support index-map
+    "std + hashbrown + 'index-map' == 1",
+    "!(std & libm)",
+    "!('tokio-util'|'bytes-utils'|indexmap)"
+]
+always_include_features = ["strict"] # So warnings fail
 
 #[[bench]]
 #name = "resp2_decode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ rules = [
     "resp3 => (std|libm)",
     "resp3 => ('index-map'|hashbrown|std)", # because otherwise types break
     "convert => (hashbrown|std)", # convert doesn't support index-map
-    "std + hashbrown + 'index-map' == 1",
+    "std + hashbrown + 'index-map' <= 1",
     "!(std & libm)",
     "!('tokio-util'|'bytes-utils'|indexmap)"
 ]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,14 +1,22 @@
 #[cfg(feature = "resp3")]
 mod resp3 {
+  #[cfg(feature = "std")]
   use crate::{
     error::{RedisProtocolError, RedisProtocolErrorKind},
     resp3::{
       decode::streaming::decode_bytes_mut as resp3_decode,
       encode::complete::{extend_encode as resp3_encode, extend_encode_borrowed as resp3_encode_borrowed},
-      types::{BorrowedFrame, BytesFrame as Resp3Frame, StreamedFrame},
+      types::{BorrowedFrame},
+    },
+  };  
+  use crate::{
+    resp3::{
+      types::{BytesFrame as Resp3Frame, StreamedFrame},
     },
   };
+  #[cfg(feature = "std")]
   use bytes::BytesMut;
+  #[cfg(feature = "std")]
   use tokio_util::codec::{Decoder, Encoder};
   /// Encode a redis command string (`SET foo bar NX`, etc) into a RESP3 blob string array.
   pub fn resp3_encode_command(cmd: &str) -> Resp3Frame {
@@ -60,7 +68,9 @@ mod resp3 {
   /// ```
   #[derive(Debug, Default)]
   pub struct Resp3 {
+    #[cfg_attr(not(feature = "std"), allow(dead_code))]
     streaming:         Option<StreamedFrame<Resp3Frame>>,
+    #[cfg_attr(not(feature = "std"), allow(dead_code))]
     int_as_blobstring: bool,
   }
 
@@ -75,6 +85,7 @@ mod resp3 {
     }
   }
 
+  #[cfg(feature = "std")]
   impl Encoder<Resp3Frame> for Resp3 {
     type Error = RedisProtocolError;
 
@@ -85,6 +96,7 @@ mod resp3 {
     }
   }
 
+  #[cfg(feature = "std")]
   impl Encoder<BorrowedFrame<'_>> for Resp3 {
     type Error = RedisProtocolError;
 
@@ -95,6 +107,7 @@ mod resp3 {
     }
   }
 
+  #[cfg(feature = "std")]
   impl Decoder for Resp3 {
     type Error = RedisProtocolError;
     type Item = Resp3Frame;
@@ -145,15 +158,23 @@ mod resp3 {
 
 #[cfg(feature = "resp2")]
 mod resp2 {
+  #[cfg(feature = "std")]
   use crate::{
     error::RedisProtocolError,
     resp2::{
       decode::decode_bytes_mut as resp2_decode,
       encode::{extend_encode as resp2_encode, extend_encode_borrowed as resp2_encode_borrowed},
-      types::{BorrowedFrame, BytesFrame as Resp2Frame},
+      types::BorrowedFrame,
     },
   };
+  use crate::{
+    resp2::{
+      types::BytesFrame as Resp2Frame,
+    },
+  };
+  #[cfg(feature = "std")]
   use bytes::BytesMut;
+  #[cfg(feature = "std")]
   use tokio_util::codec::{Decoder, Encoder};
   /// Encode a redis command string (`SET foo bar NX`, etc) into a RESP2 bulk string array.
   pub fn resp2_encode_command(cmd: &str) -> Resp2Frame {
@@ -194,6 +215,7 @@ mod resp2 {
   /// ```
   #[derive(Clone, Debug, Default)]
   pub struct Resp2 {
+    #[cfg_attr(not(feature = "std"), allow(dead_code))]
     int_as_bulkstring: bool,
   }
 
@@ -205,6 +227,7 @@ mod resp2 {
     }
   }
 
+  #[cfg(feature = "std")]
   impl Encoder<Resp2Frame> for Resp2 {
     type Error = RedisProtocolError;
 
@@ -215,6 +238,7 @@ mod resp2 {
     }
   }
 
+  #[cfg(feature = "std")]
   impl Encoder<BorrowedFrame<'_>> for Resp2 {
     type Error = RedisProtocolError;
 
@@ -225,6 +249,7 @@ mod resp2 {
     }
   }
 
+  #[cfg(feature = "std")]
   impl Decoder for Resp2 {
     type Error = RedisProtocolError;
     type Item = Resp2Frame;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,14 +6,10 @@ mod resp3 {
     resp3::{
       decode::streaming::decode_bytes_mut as resp3_decode,
       encode::complete::{extend_encode as resp3_encode, extend_encode_borrowed as resp3_encode_borrowed},
-      types::{BorrowedFrame},
+      types::{BorrowedFrame, StreamedFrame},
     },
   };  
-  use crate::{
-    resp3::{
-      types::{BytesFrame as Resp3Frame, StreamedFrame},
-    },
-  };
+  use crate::resp3::types::BytesFrame as Resp3Frame;
   #[cfg(feature = "std")]
   use bytes::BytesMut;
   #[cfg(feature = "std")]
@@ -68,20 +64,26 @@ mod resp3 {
   /// ```
   #[derive(Debug, Default)]
   pub struct Resp3 {
-    #[cfg_attr(not(feature = "std"), allow(dead_code))]
+    #[cfg(feature = "std")]
     streaming:         Option<StreamedFrame<Resp3Frame>>,
-    #[cfg_attr(not(feature = "std"), allow(dead_code))]
+    #[cfg(feature = "std")]
     int_as_blobstring: bool,
   }
 
   impl Resp3 {
     /// Create a new codec with the provided flag describing whether the encoder logic should send integers as blob
     /// strings.
+    #[cfg(feature = "std")]
     pub fn new(int_as_blobstring: bool) -> Resp3 {
-      Resp3 {
+      Self {
         int_as_blobstring,
         streaming: None,
       }
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn new() -> Resp3 {      
+      Self {}
     }
   }
 
@@ -215,15 +217,20 @@ mod resp2 {
   /// ```
   #[derive(Clone, Debug, Default)]
   pub struct Resp2 {
-    #[cfg_attr(not(feature = "std"), allow(dead_code))]
+    #[cfg(feature = "std")]
     int_as_bulkstring: bool,
   }
 
   impl Resp2 {
     /// Create a new codec with the provided flag describing whether the encoder logic should send integers as blob
     /// strings.
-    pub fn new(int_as_bulkstring: bool) -> Resp2 {
-      Resp2 { int_as_bulkstring }
+    #[cfg(feature = "std")]
+    pub fn new(int_as_bulkstring: bool) -> Self {
+      Self { int_as_bulkstring }
+    }
+    #[cfg(not(feature = "std"))]
+    pub fn new() -> Self {
+      Self {}
     }
   }
 

--- a/src/int2dec.rs
+++ b/src/int2dec.rs
@@ -104,6 +104,7 @@ pub fn u64_to_digits(n: u64) -> (Digits64, usize) {
   (buf, padding(&buf[0 ..], 0))
 }
 
+#[cfg(any(feature="resp2", feature="resp3"))]
 #[inline]
 pub fn i64_to_digits(n: i64) -> (Digits64, usize) {
   // padding will always be >= 1 in this context

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,15 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(feature = "strict", deny(warnings))]
 #![doc = include_str!("../README.md")]
 
 extern crate alloc;
 extern crate core;
 
-#[macro_use]
+#[cfg_attr(any(feature="resp3", all(feature = "convert", feature="decode-logs", feature="std", any(feature="resp2", feature = "resp3"))), macro_use)]
 extern crate log;
-#[macro_use]
+#[cfg_attr(any(feature = "resp2", feature = "resp3"), macro_use)]
 extern crate cookie_factory;
 
 #[cfg(feature = "bytes")]
@@ -37,6 +38,7 @@ pub extern crate tokio_util;
 mod macros;
 /// Error types.
 pub mod error;
+#[cfg(any(feature="resp2", feature="resp3"))]
 mod int2dec;
 mod utils;
 
@@ -63,8 +65,11 @@ pub mod convert;
 
 #[cfg(feature = "bytes")]
 pub use utils::zero_extend;
-pub use utils::{digits_in_i64, digits_in_usize, redis_keyslot, str_to_f64};
+#[cfg(any(feature = "std", feature="libm"))]
+pub use utils::{digits_in_i64, digits_in_usize};
+pub use utils::{redis_keyslot, str_to_f64};
 
+#[cfg(any(feature = "std", feature="libm"))]
 #[deprecated(since = "5.1.0", note = "Use `digits_in_usize` instead.")]
 pub fn digits_in_number(d: usize) -> usize {
   digits_in_usize(d)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature="resp2", feature="resp3"))]
 macro_rules! encode_checks(
   ($buf:ident, $offset:expr, $required:expr) => {
     let required = $required;
@@ -9,7 +10,7 @@ macro_rules! encode_checks(
   }
 );
 
-#[cfg(feature = "convert")]
+#[cfg(all(feature = "convert", any(feature="resp2", feature = "resp3")))]
 macro_rules! debug_type(
   ($($arg:tt)*) => {
     #[cfg(all(feature="decode-logs", feature = "std"))]
@@ -17,12 +18,14 @@ macro_rules! debug_type(
   }
 );
 
+#[cfg(any(feature="resp2", feature="resp3"))]
 macro_rules! e (
   ($err:expr) => {
     return Err(RedisParseError::from($err).into_nom_error())
   }
 );
 
+#[cfg(any(feature="resp2", feature="resp3"))]
 macro_rules! etry (
   ($expr:expr) => {
     match $expr {
@@ -32,6 +35,7 @@ macro_rules! etry (
   }
 );
 
+#[cfg(any(feature="resp2", feature="resp3"))]
 macro_rules! decode_log(
   ($($arg:tt)*) => (
     #[cfg(feature = "decode-logs")]
@@ -43,6 +47,7 @@ macro_rules! decode_log(
   );
 );
 
+#[cfg(any(feature="resp2", feature="resp3"))]
 macro_rules! decode_log_str(
   ($buf:expr, $name:ident, $($arg:tt)*) => (
     #[cfg(feature = "decode-logs")]
@@ -60,7 +65,7 @@ macro_rules! decode_log_str(
   )
 );
 
-#[cfg(feature = "convert")]
+#[cfg(all(feature = "convert", any(feature="resp2", feature="resp3")))]
 macro_rules! check_single_vec_reply(
   ($v:expr) => {
     if $v.is_single_element_vec() {

--- a/src/resp2/decode.rs
+++ b/src/resp2/decode.rs
@@ -37,25 +37,25 @@ fn to_i64(s: &[u8]) -> Result<i64, RedisParseError<&[u8]>> {
     .map_err(|_| RedisParseError::new_custom("to_i64", "Failed to parse as integer."))
 }
 
-fn d_read_to_crlf(input: (&[u8], usize)) -> DResult<usize> {
+fn d_read_to_crlf(input: (&[u8], usize)) -> DResult<'_, usize> {
   decode_log_str!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", _input);
   let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
   Ok(((input_bytes, input.1 + data.len() + 2), data.len()))
 }
 
-fn d_read_to_crlf_take(input: (&[u8], usize)) -> DResult<&[u8]> {
+fn d_read_to_crlf_take(input: (&[u8], usize)) -> DResult<'_, &[u8]> {
   decode_log_str!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", _input);
   let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
   Ok(((input_bytes, input.1 + data.len() + 2), data))
 }
 
-fn d_read_prefix_len(input: (&[u8], usize)) -> DResult<isize> {
+fn d_read_prefix_len(input: (&[u8], usize)) -> DResult<'_, isize> {
   let (input, data) = d_read_to_crlf_take(input)?;
   decode_log!("Reading prefix len. Data: {:?}", str::from_utf8(data));
   Ok((input, etry!(to_isize(data))))
 }
 
-fn d_frame_type(input: (&[u8], usize)) -> DResult<FrameKind> {
+fn d_frame_type(input: (&[u8], usize)) -> DResult<'_, FrameKind> {
   let (input_bytes, byte) = be_u8(input.0)?;
   decode_log_str!(
     input_bytes,
@@ -76,13 +76,13 @@ fn d_frame_type(input: (&[u8], usize)) -> DResult<FrameKind> {
   Ok(((input_bytes, input.1 + 1), kind))
 }
 
-fn d_parse_simplestring(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_simplestring(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let ((input, next_offset), len) = d_read_to_crlf(input)?;
   Ok(((input, next_offset), RangeFrame::SimpleString((offset, offset + len))))
 }
 
-fn d_parse_integer(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_integer(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
   let parsed = etry!(to_i64(data));
   Ok(((input, next_offset), RangeFrame::Integer(parsed)))
@@ -90,17 +90,17 @@ fn d_parse_integer(input: (&[u8], usize)) -> DResult<RangeFrame> {
 
 // assumes the '$-1\r\n' has been consumed already, since nulls look like bulk strings until the length prefix is
 // parsed, and parsing the length prefix consumes the trailing \r\n in the underlying `terminated!` call
-fn d_parse_null(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_null(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   Ok((input, RangeFrame::Null))
 }
 
-fn d_parse_error(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_error(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let ((input, next_offset), len) = d_read_to_crlf(input)?;
   Ok(((input, next_offset), RangeFrame::Error((offset, offset + len))))
 }
 
-fn d_parse_bulkstring(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
+fn d_parse_bulkstring(input: (&[u8], usize), len: usize) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let (input, data) = nom_terminated(nom_take(len), nom_take(2_usize))(input.0)?;
   Ok((
@@ -109,7 +109,7 @@ fn d_parse_bulkstring(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> 
   ))
 }
 
-fn d_parse_bulkstring_or_null(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_bulkstring_or_null(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, offset), len) = d_read_prefix_len(input)?;
   decode_log_str!(
     input,
@@ -126,7 +126,7 @@ fn d_parse_bulkstring_or_null(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }
 }
 
-fn d_parse_array_frames(input: (&[u8], usize), len: usize) -> DResult<Vec<RangeFrame>> {
+fn d_parse_array_frames(input: (&[u8], usize), len: usize) -> DResult<'_, Vec<RangeFrame>> {
   decode_log_str!(
     input.0,
     _input,
@@ -137,7 +137,7 @@ fn d_parse_array_frames(input: (&[u8], usize), len: usize) -> DResult<Vec<RangeF
   nom_count(d_parse_frame, len)(input)
 }
 
-fn d_parse_array(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_array(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, offset), len) = d_read_prefix_len(input)?;
   decode_log_str!(
     input,
@@ -156,7 +156,7 @@ fn d_parse_array(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }
 }
 
-fn d_parse_frame(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_frame(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, offset), kind) = d_frame_type(input)?;
   decode_log_str!(input, _input, "Parsed kind: {:?}, remaining: {:?}", kind, _input);
 

--- a/src/resp3/decode.rs
+++ b/src/resp3/decode.rs
@@ -111,31 +111,31 @@ fn attach_attributes<T>(
   }
 }
 
-fn d_read_to_crlf(input: (&[u8], usize)) -> DResult<usize> {
+fn d_read_to_crlf(input: (&[u8], usize)) -> DResult<'_, usize> {
   decode_log_str!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", input);
   let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
   Ok(((input_bytes, input.1 + data.len() + 2), data.len()))
 }
 
-fn d_read_to_crlf_take(input: (&[u8], usize)) -> DResult<&[u8]> {
+fn d_read_to_crlf_take(input: (&[u8], usize)) -> DResult<'_, &[u8]> {
   decode_log_str!(input.0, _input, "Parsing to CRLF. Remaining: {:?}", _input);
   let (input_bytes, data) = nom_terminated(nom_take_until(CRLF.as_bytes()), nom_take(2_usize))(input.0)?;
   Ok(((input_bytes, input.1 + data.len() + 2), data))
 }
 
-fn d_read_prefix_len(input: (&[u8], usize)) -> DResult<usize> {
+fn d_read_prefix_len(input: (&[u8], usize)) -> DResult<'_, usize> {
   let ((input, offset), data) = d_read_to_crlf_take(input)?;
   decode_log!("Reading prefix len. Data: {:?}", str::from_utf8(data));
   Ok(((input, offset), etry!(parse_as::<usize, _>(data))))
 }
 
-fn d_read_prefix_len_signed(input: (&[u8], usize)) -> DResult<isize> {
+fn d_read_prefix_len_signed(input: (&[u8], usize)) -> DResult<'_, isize> {
   let ((input, offset), data) = d_read_to_crlf_take(input)?;
   decode_log!("Reading prefix len. Data: {:?}", str::from_utf8(data));
   Ok(((input, offset), etry!(to_isize(data))))
 }
 
-fn d_frame_type(input: (&[u8], usize)) -> DResult<FrameKind> {
+fn d_frame_type(input: (&[u8], usize)) -> DResult<'_, FrameKind> {
   let (input_bytes, byte) = nom_be_u8(input.0)?;
 
   match FrameKind::from_byte(byte) {
@@ -161,7 +161,7 @@ fn d_frame_type(input: (&[u8], usize)) -> DResult<FrameKind> {
   }
 }
 
-fn d_parse_simplestring(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_simplestring(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let ((input, next_offset), len) = d_read_to_crlf(input)?;
   Ok(((input, next_offset), RangeFrame::SimpleString {
@@ -170,7 +170,7 @@ fn d_parse_simplestring(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_simpleerror(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_simpleerror(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let ((input, next_offset), len) = d_read_to_crlf(input)?;
   Ok(((input, next_offset), RangeFrame::SimpleError {
@@ -179,7 +179,7 @@ fn d_parse_simpleerror(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_number(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_number(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
   let parsed = etry!(parse_as::<i64, _>(data));
   Ok(((input, next_offset), RangeFrame::Number {
@@ -188,7 +188,7 @@ fn d_parse_number(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_double(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_double(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
   let parsed = etry!(parse_as::<f64, _>(data));
   Ok(((input, next_offset), RangeFrame::Double {
@@ -197,7 +197,7 @@ fn d_parse_double(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_boolean(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_boolean(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, next_offset), data) = d_read_to_crlf_take(input)?;
   let parsed = etry!(to_bool(data));
   Ok(((input, next_offset), RangeFrame::Boolean {
@@ -206,12 +206,12 @@ fn d_parse_boolean(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_null(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_null(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, next_offset), _) = d_read_to_crlf(input)?;
   Ok(((input, next_offset), RangeFrame::Null))
 }
 
-fn d_parse_blobstring(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
+fn d_parse_blobstring(input: (&[u8], usize), len: usize) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let (input, data) = nom_terminated(nom_take(len), nom_take(2_usize))(input.0)?;
 
@@ -221,7 +221,7 @@ fn d_parse_blobstring(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> 
   }))
 }
 
-fn d_parse_bloberror(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_bloberror(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, offset), len) = d_read_prefix_len(input)?;
   let (input, data) = nom_terminated(nom_take(len), nom_take(2_usize))(input)?;
 
@@ -231,7 +231,7 @@ fn d_parse_bloberror(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_verbatimstring(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_verbatimstring(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let ((input, prefix_offset), len) = d_read_prefix_len(input)?;
   let (input, format_bytes) = nom_terminated(nom_take(3_usize), nom_take(1_usize))(input)?;
   if len < 4 {
@@ -252,7 +252,7 @@ fn d_parse_verbatimstring(input: (&[u8], usize)) -> DResult<RangeFrame> {
   ))
 }
 
-fn d_parse_bignumber(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_bignumber(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let offset = input.1;
   let ((input, next_offset), len) = d_read_to_crlf(input)?;
 
@@ -262,14 +262,14 @@ fn d_parse_bignumber(input: (&[u8], usize)) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_array_frames(input: (&[u8], usize), len: usize) -> DResult<Vec<RangeFrame>> {
+fn d_parse_array_frames(input: (&[u8], usize), len: usize) -> DResult<'_, Vec<RangeFrame>> {
   nom_count(
     nom_map_res(d_parse_frame_or_attribute, expect_complete_index_frame::<&[u8]>),
     len,
   )(input)
 }
 
-fn d_parse_kv_pairs(input: (&[u8], usize), len: usize) -> DResult<FrameMap<RangeFrame, RangeFrame>> {
+fn d_parse_kv_pairs(input: (&[u8], usize), len: usize) -> DResult<'_, FrameMap<RangeFrame, RangeFrame>> {
   nom_map_res(
     nom_count(
       nom_map_res(d_parse_frame_or_attribute, expect_complete_index_frame::<&[u8]>),
@@ -279,18 +279,18 @@ fn d_parse_kv_pairs(input: (&[u8], usize), len: usize) -> DResult<FrameMap<Range
   )(input)
 }
 
-fn d_parse_array(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
+fn d_parse_array(input: (&[u8], usize), len: usize) -> DResult<'_, RangeFrame> {
   let (input, data) = d_parse_array_frames(input, len)?;
   Ok((input, RangeFrame::Array { data, attributes: None }))
 }
 
-fn d_parse_push(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_push(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   let (input, len) = d_read_prefix_len(input)?;
   let (input, data) = d_parse_array_frames(input, len)?;
   Ok((input, RangeFrame::Push { data, attributes: None }))
 }
 
-fn d_parse_set(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
+fn d_parse_set(input: (&[u8], usize), len: usize) -> DResult<'_, RangeFrame> {
   let (input, frames) = d_parse_array_frames(input, len)?;
 
   Ok((input, RangeFrame::Set {
@@ -299,7 +299,7 @@ fn d_parse_set(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_map(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
+fn d_parse_map(input: (&[u8], usize), len: usize) -> DResult<'_, RangeFrame> {
   let (input, frames) = d_parse_kv_pairs(input, len)?;
 
   Ok((input, RangeFrame::Map {
@@ -308,13 +308,13 @@ fn d_parse_map(input: (&[u8], usize), len: usize) -> DResult<RangeFrame> {
   }))
 }
 
-fn d_parse_attribute(input: (&[u8], usize)) -> DResult<RangeAttributes> {
+fn d_parse_attribute(input: (&[u8], usize)) -> DResult<'_, RangeAttributes> {
   let (input, len) = d_read_prefix_len(input)?;
   let (input, attributes) = d_parse_kv_pairs(input, len)?;
   Ok((input, attributes))
 }
 
-fn d_parse_hello(input: (&[u8], usize)) -> DResult<RangeFrame> {
+fn d_parse_hello(input: (&[u8], usize)) -> DResult<'_, RangeFrame> {
   // HELLO [protover [AUTH username password] [SETNAME clientname]]\r\n
   // The HELLO definition seems somewhat undefined, nor does it use length prefixes or CRLF delimiters, so most of the
   // above logic isn't useful here. this is hacky and should be improved
@@ -393,7 +393,7 @@ fn d_parse_hello(input: (&[u8], usize)) -> DResult<RangeFrame> {
 /// complete frame.
 ///
 /// Only supported for arrays, sets, maps, and blob strings.
-fn d_check_streaming(input: (&[u8], usize), kind: FrameKind) -> DResult<DecodedRangeFrame> {
+fn d_check_streaming(input: (&[u8], usize), kind: FrameKind) -> DResult<'_, DecodedRangeFrame> {
   let (input, len) = d_read_prefix_len_signed(input)?;
   let (input, frame) = if len == -1 {
     (input, DecodedRangeFrame::Streaming(StreamedRangeFrame::new(kind)))
@@ -416,7 +416,7 @@ fn d_check_streaming(input: (&[u8], usize), kind: FrameKind) -> DResult<DecodedR
   Ok((input, frame))
 }
 
-fn d_parse_chunked_string(input: (&[u8], usize)) -> DResult<DecodedRangeFrame> {
+fn d_parse_chunked_string(input: (&[u8], usize)) -> DResult<'_, DecodedRangeFrame> {
   let (input, len) = d_read_prefix_len(input)?;
   let (input, frame) = if len == 0 {
     (input, RangeFrame::new_end_stream())
@@ -433,12 +433,12 @@ fn d_parse_chunked_string(input: (&[u8], usize)) -> DResult<DecodedRangeFrame> {
   Ok((input, DecodedRangeFrame::Complete(frame)))
 }
 
-fn d_return_end_stream(input: (&[u8], usize)) -> DResult<DecodedRangeFrame> {
+fn d_return_end_stream(input: (&[u8], usize)) -> DResult<'_, DecodedRangeFrame> {
   let (input, _) = d_read_to_crlf(input)?;
   Ok((input, DecodedRangeFrame::Complete(RangeFrame::new_end_stream())))
 }
 
-fn d_parse_non_attribute_frame(input: (&[u8], usize), kind: FrameKind) -> DResult<DecodedRangeFrame> {
+fn d_parse_non_attribute_frame(input: (&[u8], usize), kind: FrameKind) -> DResult<'_, DecodedRangeFrame> {
   let (input, frame) = match kind {
     FrameKind::Array => d_check_streaming(input, kind)?,
     FrameKind::BlobString => d_check_streaming(input, kind)?,
@@ -468,7 +468,7 @@ fn d_parse_non_attribute_frame(input: (&[u8], usize), kind: FrameKind) -> DResul
   Ok((input, frame))
 }
 
-fn d_parse_attribute_and_frame(input: (&[u8], usize)) -> DResult<DecodedRangeFrame> {
+fn d_parse_attribute_and_frame(input: (&[u8], usize)) -> DResult<'_, DecodedRangeFrame> {
   let (input, attributes) = d_parse_attribute(input)?;
   let (input, kind) = d_frame_type(input)?;
   let (input, next_frame) = d_parse_non_attribute_frame(input, kind)?;
@@ -477,7 +477,7 @@ fn d_parse_attribute_and_frame(input: (&[u8], usize)) -> DResult<DecodedRangeFra
   Ok((input, frame))
 }
 
-fn d_parse_frame_or_attribute(input: (&[u8], usize)) -> DResult<DecodedRangeFrame> {
+fn d_parse_frame_or_attribute(input: (&[u8], usize)) -> DResult<'_, DecodedRangeFrame> {
   let (input, kind) = d_frame_type(input)?;
   let (input, frame) = if kind == FrameKind::Attribute {
     d_parse_attribute_and_frame(input)?

--- a/src/resp3/utils.rs
+++ b/src/resp3/utils.rs
@@ -18,12 +18,18 @@ use bytes::{Bytes, BytesMut};
 #[cfg(feature = "bytes")]
 use bytes_utils::Str;
 
-#[cfg(feature = "hashbrown")]
-use hashbrown::{HashMap, HashSet};
-#[cfg(feature = "index-map")]
-use indexmap::{IndexMap, IndexSet};
-#[cfg(feature = "std")]
-use std::collections::{HashMap, HashSet};
+#[cfg(all(feature = "resp3", test, feature="hashbrown"))]
+use hashbrown::HashSet;
+#[cfg(all(feature = "resp3", feature="hashbrown"))]
+use hashbrown::HashMap;
+#[cfg(all(feature = "resp3", test, feature = "index-map"))]
+use indexmap::IndexSet;
+#[cfg(all(feature = "resp3", feature = "index-map"))]
+use indexmap::IndexMap;
+#[cfg(all(feature = "resp3", test, feature="std"))]
+use std::collections::HashSet;
+#[cfg(all(feature = "resp3", feature="std"))]
+use std::collections::HashMap;
 
 pub const BOOLEAN_ENCODE_LEN: usize = 4;
 
@@ -32,23 +38,22 @@ pub fn hash_tuple<H: Hasher>(state: &mut H, range: &(usize, usize)) {
   range.1.hash(state);
 }
 
-#[cfg(not(feature = "index-map"))]
-#[allow(dead_code)]
+#[cfg(all(feature = "resp3", test, any(feature = "hashbrown", feature="std")))]
 pub fn new_set<K: Hash + Eq>(capacity: usize) -> HashSet<K> {
   HashSet::with_capacity(capacity)
 }
 
-#[cfg(feature = "index-map")]
+#[cfg(all(feature = "resp3", test, feature = "index-map"))]
 pub fn new_set<K: Hash + Eq>(capacity: usize) -> IndexSet<K> {
   IndexSet::with_capacity(capacity)
 }
 
-#[cfg(not(feature = "index-map"))]
+#[cfg(all(feature = "resp3", any(feature = "hashbrown", feature="std")))]
 pub fn new_map<K: Hash + Eq, V>(capacity: usize) -> HashMap<K, V> {
   HashMap::with_capacity(capacity)
 }
 
-#[cfg(feature = "index-map")]
+#[cfg(all(feature = "resp3", feature = "index-map"))]
 pub fn new_map<K: Hash + Eq, V>(capacity: usize) -> IndexMap<K, V> {
   IndexMap::with_capacity(capacity)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,12 @@
+#[cfg(any(feature="resp2", feature="resp3"))]
 use crate::error::RedisParseError;
+#[cfg(any(feature="resp2", feature="resp3"))]
 use nom::IResult;
 
 /// Alternative alias for `std::ops::Range`.
 pub(crate) type _Range = (usize, usize);
 /// A wrapper type for the nom result type that stores range offsets alongside the buffer.
+#[cfg(any(feature="resp2", feature="resp3"))]
 pub(crate) type DResult<'a, T> = IResult<(&'a [u8], usize), T, RedisParseError<&'a [u8]>>;
 
 /// Terminating bytes between frames.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
-use crate::error::{RedisParseError, RedisProtocolError, RedisProtocolErrorKind};
+#[cfg(any(feature="resp2", feature="resp3"))]
+use crate::error::RedisParseError;
+use crate::error::{RedisProtocolError, RedisProtocolErrorKind};
 use core::str;
 use crc16::{State, XMODEM};
 
@@ -48,6 +50,7 @@ pub fn digits_in_i64(d: i64) -> usize {
   prefix + libm::floor(libm::log10(d.unsigned_abs() as f64)) as usize + 1
 }
 
+#[cfg(any(feature="resp2", feature="resp3"))]
 pub fn isize_to_usize<T>(val: isize) -> Result<usize, RedisParseError<T>> {
   if val >= 0 {
     Ok(val as usize)
@@ -64,6 +67,7 @@ pub fn zero_extend(buf: &mut BytesMut, amt: usize) {
 }
 
 /// Whether an error payload is a `MOVED` or `ASK` redirection.
+#[cfg(any(feature="resp2", feature="resp3"))]
 pub(crate) fn is_redirection(payload: &str) -> bool {
   if payload.starts_with("MOVED") || payload.starts_with("ASK") {
     payload.split(' ').count() == 3
@@ -139,6 +143,7 @@ pub fn str_to_f64(s: &str) -> Result<f64, RedisProtocolError> {
 }
 
 /// Convert bytes to a boolean.
+#[cfg(any(feature="resp2", feature="resp3"))]
 pub(crate) fn bytes_to_bool(b: &[u8]) -> Option<bool> {
   match b {
     b"true" | b"TRUE" | b"t" | b"T" | b"1" => Some(true),

--- a/tests/codec/mod.rs
+++ b/tests/codec/mod.rs
@@ -1,12 +1,17 @@
 use futures::{SinkExt, StreamExt};
+#[cfg(feature = "resp2")]
 use redis_protocol::{
-  codec::{resp2_encode_command, resp3_encode_command, Resp2, Resp3},
+  codec::{resp2_encode_command,Resp2},
   resp2::types::{
     BorrowedFrame as Resp2BorrowedFrame,
     BytesFrame as Resp2BytesFrame,
     FrameKind as Resp2FrameKind,
     Resp2Frame,
   },
+};
+#[cfg(feature = "resp3")]
+use redis_protocol::{
+  codec::{resp3_encode_command, Resp3},
   resp3::types::{
     BorrowedFrame as Resp3BorrowedFrame,
     BytesFrame as Resp3BytesFrame,
@@ -16,32 +21,41 @@ use redis_protocol::{
     RespVersion,
   },
 };
+#[cfg(any(feature = "resp2", feature="resp3"))]
 use std::env;
+#[cfg(any(feature = "resp2", feature="resp3"))]
 use tokio::net::TcpStream;
+#[cfg(any(feature = "resp2", feature="resp3"))]
 use tokio_util::codec::Framed;
 
+#[cfg(all(feature="std", any(feature = "resp2", feature="resp3")))]
 fn read_env_var(name: &str) -> Option<String> {
   env::var_os(name).and_then(|s| s.into_string().ok())
 }
 
+#[cfg(all(feature="std", any(feature = "resp2", feature="resp3")))]
 fn read_redis_centralized_host() -> String {
   read_env_var("FRED_REDIS_CENTRALIZED_HOST").unwrap_or("redis-main".into())
 }
 
+#[cfg(all(feature="std", any(feature = "resp2", feature="resp3")))]
 fn read_redis_centralized_port() -> u16 {
   read_env_var("FRED_REDIS_CENTRALIZED_PORT")
     .and_then(|s| s.parse::<u16>().ok())
     .unwrap_or(6383)
 }
 
+#[cfg(all(feature = "resp3", feature="std"))]
 fn read_redis_password() -> String {
   read_env_var("REDIS_PASSWORD").expect("Failed to read REDIS_PASSWORD env")
 }
 
+#[cfg(all(feature = "resp3", feature="std"))]
 fn read_redis_username() -> String {
   read_env_var("REDIS_USERNAME").expect("Failed to read REDIS_USERNAME env")
 }
 
+#[cfg(all(feature = "resp2", feature="std"))]
 async fn connect_resp2(int_as_bulkstring: bool) -> Framed<TcpStream, Resp2> {
   let addr = format!("{}:{}", read_redis_centralized_host(), read_redis_centralized_port());
   debug!("Connecting to {}", addr);
@@ -49,6 +63,7 @@ async fn connect_resp2(int_as_bulkstring: bool) -> Framed<TcpStream, Resp2> {
   Framed::new(socket, Resp2::new(int_as_bulkstring))
 }
 
+#[cfg(all(feature = "resp3", feature="std"))]
 async fn connect_resp3(int_as_blobstring: bool) -> Framed<TcpStream, Resp3> {
   let addr = format!("{}:{}", read_redis_centralized_host(), read_redis_centralized_port());
   debug!("Connecting to {}", addr);
@@ -57,6 +72,7 @@ async fn connect_resp3(int_as_blobstring: bool) -> Framed<TcpStream, Resp3> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp2", feature="std"))]
 async fn should_use_resp2_codec_ping() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp2(false).await;
@@ -68,6 +84,7 @@ async fn should_use_resp2_codec_ping() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp2", feature="std"))]
 async fn should_use_resp2_codec_borrowed_ping_incr() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp2(true).await;
@@ -90,6 +107,7 @@ async fn should_use_resp2_codec_borrowed_ping_incr() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp2", feature="std"))]
 async fn should_use_resp2_codec_get_set() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp2(false).await;
@@ -116,6 +134,7 @@ async fn should_use_resp2_codec_get_set() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp2", feature="std"))]
 async fn should_use_resp2_codec_hgetall() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp2(false).await;
@@ -145,6 +164,7 @@ async fn should_use_resp2_codec_hgetall() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp3", feature="std"))]
 async fn should_use_resp3_codec_hello() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp3(false).await;
@@ -187,6 +207,7 @@ async fn should_use_resp3_codec_hello() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp3", feature="std"))]
 async fn should_use_resp3_codec_get_set() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp3(false).await;
@@ -225,6 +246,7 @@ async fn should_use_resp3_codec_get_set() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "resp3", feature="std"))]
 async fn should_use_resp3_codec_hgetall() {
   let _ = pretty_env_logger::try_init();
   let mut socket = connect_resp3(false).await;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::disallowed_names)]
 #![allow(unused_imports)]
+#![cfg_attr(feature = "strict", deny(warnings))]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Fixes https://github.com/aembke/redis-protocol.rs/issues/41 by making sure every combination of the features compiles. I've tested this using `cargo build-all-features --tests`, but this needs that installed from https://github.com/frewsxcv/cargo-all-features/pull/50 for more complicated rules support.

~~Note that a couple of the features are untested, probably because of bugs in the upstream - definitely `codec` and `bytes` for starters. I'll follow up there on those.~~ Resolved by making the `bytes` dependency `dep:bytes-util` which fixed the exclude for running the optional dependency as a feature.