### PR TITLE
Brings resp2_decode up to date with modern criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1.36", features = ["full"] }
 pretty_env_logger = "0.5"
 futures = "0.3"
 itertools = "0.12"
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 
 [features]
 default = ["std", "resp2", "resp3"]
@@ -60,9 +60,9 @@ doctest = true
 name = "redis_protocol"
 test = true
 
-#[[bench]]
-#name = "resp2_decode"
-#harness = false
+[[bench]]
+name = "resp2_decode"
+harness = false
 
 #[[bench]]
 #name = "resp2_encode"

--- a/README.md
+++ b/README.md
@@ -226,3 +226,11 @@ fn main() {
 }
 
 ```
+
+## Benches
+To run the benchmarks:
+
+```
+cargo install cargo-criterion
+cargo criterion
+```

--- a/benches/resp2_decode.rs
+++ b/benches/resp2_decode.rs
@@ -1,4 +1,8 @@
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Bencher, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(feature = "bytes")]
+use criterion::{BatchSize, Bencher};
 use rand::{distributions::Alphanumeric, Rng};
 use redis_protocol::{
   resp2::{decode, types::NULL},


### PR DESCRIPTION
Re-enables `resp2_decode` bench. Started prodding at porting an older resp2 encode bench, but that started to get tricky without copy/pasting a lot of the `BytesMutInput`, etc helpers